### PR TITLE
Automate inclusion of short arguments

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -285,20 +285,6 @@ class AddArgumentTests(TestCase):
 
         self.assertEqual(self.args.arg_str, arg_str)
 
-    def test_one_and_two_dashes(self) -> None:
-        class IntegrationAddArgumentTap(IntegrationDefaultTap):
-            def add_arguments(self) -> None:
-                self.add_argument('-a', '--arg_str')
-
-        arg_str = 'one_or_two_dashes'
-        self.args = IntegrationAddArgumentTap().parse_args(['-a', arg_str])
-
-        self.assertEqual(self.args.arg_str, arg_str)
-
-        self.args = IntegrationAddArgumentTap().parse_args(['--arg_str', arg_str])
-
-        self.assertEqual(self.args.arg_str, arg_str)
-
     def test_not_class_variable(self) -> None:
         class IntegrationAddArgumentTap(IntegrationDefaultTap):
             def add_arguments(self) -> None:


### PR DESCRIPTION
I like this code's efficiency, and wanted to make short arguments available by default.

All tests are passing. `tests/test_integration:test_one_and_two_dashes` had failed (and became redundant since its coverage happens during every test now).

I don't know that it should be enabled by default, but have not felt inspired as to how to toggle it without making broader changes to the overall structure.

```
cat << EOF > pull_request_demo.py
from tap import Tap


class MyTap(Tap):
    package: str
    is_cool: bool = True
    stars: int = 5


print(MyTap().parse_args())
EOF
```

**help includes short args now**
`python pull_request_demo.py --help`

    usage: pull_request_demo.py --package PACKAGE [--is_cool] [--stars STARS] [-h]

    optional arguments:
      --package PACKAGE, -p PACKAGE
                            (str, required)
      --is_cool, -i         (bool, default=True)
      --stars STARS, -s STARS
                            (int, default=5)
      -h, --help            show this help message and exit


**--package/-p work as expected**
`python pull_request_demo.py --package pr-demo0`
    MyTap(package='pr-demo0', is_cool=True, stars=5)

`python pull_request_demo.py -p pr-demo1`
    MyTap(package='pr-demo1', is_cool=True, stars=5)

**short arg flags can be used as prefixes**
`python pull_request_demo.py -ip pr-demo2 -s 3`
    MyTap(package='pr-demo2', is_cool=False, stars=3)
