### PR TITLE
Mark package as having type hints according to PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     download_url='https://github.com/swansonk14/typed-argument-parser/v_1.3.tar.gz',
     license='MIT',
     packages=find_packages(),
+    package_data={"tap": ["py.typed"]},
     install_requires=[],
     classifiers=[
         'Programming Language :: Python :: 3',
@@ -22,6 +23,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
+        "Typing :: Typed",
     ],
     keywords=[
         'typing',

--- a/tap/py.typed
+++ b/tap/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.


### PR DESCRIPTION
[PEP 561 specifies](https://www.python.org/dev/peps/pep-0561/#packaging-type-information) that packages that have type hints for their functions should include a file called "py.typed". This way, type checkers like `mypy` know that there are type hints.