### PR TITLE
Use typing.get_type_hints() instead of accessing __annotations__ directly

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -5,7 +5,7 @@ import json
 from pprint import pformat
 import sys
 import time
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union, get_type_hints
 
 from tap.utils import get_class_variables, get_dest, get_git_root, get_git_url, has_git,has_uncommitted_changes,\
     is_option_arg, type_to_str
@@ -284,7 +284,7 @@ class Tap(ArgumentParser):
     def _get_annotations(self) -> Dict[str, Any]:
         """Returns a dictionary mapping variable names to their type annotations."""
         return self._get_from_self_and_super(
-            extract_func=lambda super_class: dict(getattr(super_class, '__annotations__', dict()))
+            extract_func=lambda super_class: dict(get_type_hints(super_class))
         )
 
     def _get_class_variables(self) -> OrderedDict:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,6 +44,24 @@ class EdgeCaseTests(TestCase):
         args = OnlyTypedTap().parse_args(['--hi', hi])
         self.assertEqual(args.hi, hi)
 
+    def test_type_as_string(self) -> None:
+        class TypeAsString(Tap):
+            a_number: "int" = 3
+            a_list: "List[float]" = [3.7, 0.3]
+
+        args = TypeAsString().parse_args()
+        self.assertEqual(args.a_number, 3)
+        self.assertEqual(args.a_list, [3.7, 0.3])
+
+        a_number = 42
+        a_list = [3, 4, 0.7]
+
+        args = TypeAsString().parse_args(
+            ['--a_number', str(a_number), '--a_list'] + [str(i) for i in a_list]
+        )
+        self.assertEqual(args.a_number, a_number)
+        self.assertEqual(args.a_list, a_list)
+
 
 class RequiredClassVariableTests(TestCase):
 


### PR DESCRIPTION
[get_type_hints()](https://docs.python.org/3.6/library/typing.html#typing.get_type_hints) is the recommended way as it is safer and will still work in future versions of python where the annotations will always just be strings. See [PEP 563](https://www.python.org/dev/peps/pep-0563/) for details on that.

With this change, the following will work (see the "" around the type names):

```python
class MyArgs(Tap):
    a_number: "int" = 3
    a_list: "List[float]" = [3.7, 0.3]
```

`get_type_hints()` also fails gracefully if there are no annotations:

```
In [1]: class A:
   ...:     a = 2
   ...:

In [2]: A.__annotations__
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-bedfc1d0f51b> in <module>
----> 1 A.__annotations__

AttributeError: type object 'A' has no attribute '__annotations__'

In [3]: from typing import get_type_hints

In [4]: get_type_hints(A)
Out[4]: {}
```

I also added a test for this.