### PR TITLE
Use "Literal" types to implement arguments that only allow certain values

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ setup(
     license='MIT',
     packages=find_packages(),
     package_data={"tap": ["py.typed"]},
-    install_requires=[],
+    install_requires=[
+        'typing_extensions >= 3.7.4',
+        'typing-inspect >= 0.5',
+    ],
     classifiers=[
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import tokenize
 from typing import Any, Dict, Generator, List, Union
+from typing_inspect import get_args
 
 
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
@@ -192,3 +193,13 @@ def get_class_variables(cls: type) -> OrderedDict:
             break
 
     return variable_to_comment
+
+
+def get_string_literals(literal_type: type, variable: str) -> List[str]:
+    """Extracts the values from a Literal type and ensures that the values are all strings."""
+    choices = list(get_args(literal_type))
+    if not all(isinstance(choice, str) for choice in choices):
+        raise ValueError(
+            f'The type for variable "{variable}" contains a non-string literal.\n'
+            f'Currently only string literals are supported.')
+    return choices

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Set
 import unittest
 from unittest import TestCase
 import sys 
+from typing_extensions import Literal
 
 from tap import Tap
 
@@ -123,16 +124,20 @@ class IntegrationDefaultTap(Tap):
     # arg_bool_untyped_false = False
     arg_bool_true: bool = True
     arg_bool_false: bool = False
+    arg_str_literal: Literal['mercury', 'venus', 'mars'] = 'mars'
     arg_optional_str: Optional[str] = None
     arg_optional_int: Optional[int] = None
     arg_optional_float: Optional[float] = None
+    arg_optional_str_literal: Optional[Literal['english', 'spanish']] = None
     arg_list_str: List[str] = ['hello', 'how are you']
     arg_list_int: List[int] = [10, -11]
     arg_list_float: List[float] = [3.14, 6.28]
     arg_list_str_empty: List[str] = []
+    arg_list_str_literal: List[Literal['H', 'He', 'Li', 'Be', 'B', 'C']] = ['H', 'He']
     arg_set_str: Set[str] = {'hello', 'how are you'}
     arg_set_int: Set[int] = {10, -11}
     arg_set_float: Set[float] = {3.14, 6.28}
+    arg_set_str_literal: Set[Literal['H', 'He', 'Li', 'Be', 'B', 'C']] = {'H', 'He'}
     # TODO: move these elsewhere since we don't support them as defaults
     # arg_other_type_required: Person
     # arg_other_type_default: Person = Person('tap')
@@ -176,32 +181,40 @@ class DefaultClassVariableTests(TestCase):
         self.assertEqual(args.arg_float, 77.3)
         self.assertEqual(args.arg_bool_true, True)
         self.assertEqual(args.arg_bool_false, False)
+        self.assertEqual(args.arg_str_literal, 'mars')
         self.assertTrue(args.arg_optional_str is None)
         self.assertTrue(args.arg_optional_int is None)
         self.assertTrue(args.arg_optional_float is None)
+        self.assertTrue(args.arg_optional_str_literal is None)
         self.assertEqual(args.arg_list_str, ['hello', 'how are you'])
         self.assertEqual(args.arg_list_int, [10, -11])
         self.assertEqual(args.arg_list_float, [3.14, 6.28])
         self.assertEqual(args.arg_list_str_empty, [])
+        self.assertEqual(args.arg_list_str_literal, ['H', 'He'])
         self.assertEqual(args.arg_set_str, {'hello', 'how are you'})
         self.assertEqual(args.arg_set_int, {10, -11})
         self.assertEqual(args.arg_set_float, {3.14, 6.28})
+        self.assertEqual(args.arg_set_str_literal, {'H', 'He'})
 
     def test_set_default_args(self) -> None:
         arg_untyped = 'yes'
         arg_str = 'goodbye'
         arg_int = '2'
         arg_float = '1e-2'
+        arg_str_literal = 'venus'
         arg_optional_str = 'hello'
         arg_optional_int = '77'
         arg_optional_float = '7.7'
+        arg_optional_str_literal = 'spanish'
         arg_list_str = ['hi', 'there', 'how', 'are', 'you']
         arg_list_int = ['1', '2', '3', '10', '-11']
         arg_list_float = ['2.2', '-3.3', '2e20']
         arg_list_str_empty = []
+        arg_list_str_literal = ['Li', 'Be']
         arg_set_str = ['hi', 'hi', 'hi', 'how']
         arg_set_int = ['1', '2', '2', '2', '3']
         arg_set_float = ['1.23', '4.4', '1.23']
+        arg_set_str_literal = ['C', 'He', 'C']
 
 
         args = IntegrationDefaultTap().parse_args([
@@ -211,16 +224,20 @@ class DefaultClassVariableTests(TestCase):
             '--arg_float', arg_float,
             '--arg_bool_true',
             '--arg_bool_false',
+            '--arg_str_literal', arg_str_literal,
             '--arg_optional_str', arg_optional_str,
             '--arg_optional_int', arg_optional_int,
             '--arg_optional_float', arg_optional_float,
+            '--arg_optional_str_literal', arg_optional_str_literal,
             '--arg_list_str', *arg_list_str,
             '--arg_list_int', *arg_list_int,
             '--arg_list_float', *arg_list_float,
             '--arg_list_str_empty', *arg_list_str_empty,
+            '--arg_list_str_literal', *arg_list_str_literal,
             '--arg_set_str', *arg_set_str,
             '--arg_set_int', *arg_set_int,
-            '--arg_set_float', *arg_set_float
+            '--arg_set_float', *arg_set_float,
+            '--arg_set_str_literal', *arg_set_str_literal,
         ])
 
         arg_int = int(arg_int)
@@ -232,6 +249,7 @@ class DefaultClassVariableTests(TestCase):
         arg_set_str = set(arg_set_str)
         arg_set_int = {int(arg) for arg in arg_set_int}
         arg_set_float = {float(arg) for arg in arg_set_float}
+        arg_set_str_literal = set(arg_set_str_literal)
 
 
         self.assertEqual(args.arg_untyped, arg_untyped)
@@ -241,16 +259,20 @@ class DefaultClassVariableTests(TestCase):
         # Note: setting the bools as flags results in the opposite of their default
         self.assertEqual(args.arg_bool_true, False)
         self.assertEqual(args.arg_bool_false, True)
+        self.assertEqual(args.arg_str_literal, arg_str_literal)
         self.assertEqual(args.arg_optional_str, arg_optional_str)
         self.assertEqual(args.arg_optional_int, arg_optional_int)
         self.assertEqual(args.arg_optional_float, arg_optional_float)
+        self.assertEqual(args.arg_optional_str_literal, arg_optional_str_literal)
         self.assertEqual(args.arg_list_str, arg_list_str)
         self.assertEqual(args.arg_list_int, arg_list_int)
         self.assertEqual(args.arg_list_float, arg_list_float)
         self.assertEqual(args.arg_list_str_empty, arg_list_str_empty)
+        self.assertEqual(args.arg_list_str_literal, arg_list_str_literal)
         self.assertEqual(args.arg_set_str, arg_set_str)
         self.assertEqual(args.arg_set_int, arg_set_int)
         self.assertEqual(args.arg_set_float, arg_set_float)
+        self.assertEqual(args.arg_set_str_literal, arg_set_str_literal)
 
 
 class AddArgumentTests(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,9 +5,10 @@ from tempfile import TemporaryDirectory
 from typing import Any, Callable, List, Dict, Set, Tuple, Union
 import unittest
 from unittest import TestCase
+from typing_extensions import Literal
 
 from tap.utils import get_class_column, get_class_variables, get_git_root, get_git_url, has_uncommitted_changes,\
-    type_to_str
+    type_to_str, get_string_literals
 
 
 class GitTests(TestCase):
@@ -194,6 +195,14 @@ class ClassVariableTests(TestCase):
         class_variables['arg_2'] = {'comment': 'Arg 2 comment'}
         class_variables['arg_3'] = {'comment': 'Poorly   formatted comment'}
         self.assertEqual(get_class_variables(CommentedVariable), class_variables)
+
+
+class GetStringLiteralsTests(TestCase):
+    def test_get_string_literals(self) -> None:
+        shapes = get_string_literals(Literal['square', 'triangle', 'circle'], 'shape')
+        self.assertEqual(shapes, ['square', 'triangle', 'circle'])
+        with self.assertRaises(ValueError):
+            get_string_literals(Literal['one', 2], 'number')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With this PR, this code:

```python
class MyArgs(Tap):
   planet: Literal["mercury", "venus", "earth", "mars"] = "mars"
```

is equivalent to

```python
parser.add_argument('--planet', type=str, choices=["mercury", "venus", "earth", "mars"], default="mars")
```

The `Literal` type was [introduced in Python 3.8](https://www.python.org/dev/peps/pep-0586/) (see also [here](https://mypy.readthedocs.io/en/latest/literal_types.html) for more information) but is also available in previous versions of Python via the (official) [typing_extensions](https://github.com/python/typing/tree/master/typing_extensions) package. The type works like this:

```python
def f(a: Literal[2, "hi", 3.7]) -> None:
    print(a)

f(2)  # OK
f("ho")  # type checker will show an error (but code will run anyway)
```

So it's a perfect fit for the `choices` argument of `argparse`.

The current implementation only accepts *string* literals (i.e. `Literal[2, 3]` is not allowed) and throws an error if you try to use other literals. This could be changed but would make the code much more complicated.

This PR unfortunately introduces two dependencies: the `typing_extensions` package for the `Literal` type and the [typing_inspect](https://github.com/ilevkivskyi/typing_inspect) package (by one of the authors of the Python `typing` module) for identifying `Literal` types and extracting the values. One reason why I'm using `typing_inspect` is that the way to identify `Literal` types has changed from Python 3.6 to Python 3.7 and that package takes care of all the ugly details. It has convenient functions like `is_literal_type()`.

(Two of the functions that I use from `typing_inspect`, `get_args` and `get_origin`, have already [made it into Python 3.8](https://docs.python.org/3/library/typing.html#typing.get_origin).)