### PR TITLE
For the flag names, optionally replace underscores with dashes

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -24,12 +24,16 @@ SUPPORTED_DEFAULT_TYPES = set.union(SUPPORTED_DEFAULT_BASE_TYPES,
 class Tap(ArgumentParser):
     """Tap is a typed argument parser that wraps Python's built-in ArgumentParser."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, underscores_to_dashes: bool = False, **kwargs):
         """Initializes the Tap instance.
 
         :param args: Arguments passed to the super class ArgumentParser.
+        :param underscores_to_dashes: If True, convert underscores in flags to dashes
         :param kwargs: Keyword arguments passed to the super class ArgumentParser.
         """
+        # Whether we convert underscores in the flag names to dashes
+        self._underscores_to_dashes = underscores_to_dashes
+
         # Whether the arguments have been parsed (i.e. if parse_args has been called)
         self._parsed = False
 
@@ -143,7 +147,8 @@ class Tap(ArgumentParser):
                 name_or_flags, kwargs = self.argument_buffer[variable]
                 self._add_argument(*name_or_flags, **kwargs)
             else:
-                self._add_argument(f'--{variable}')
+                flag_name = variable.replace("_", "-") if self._underscores_to_dashes else variable
+                self._add_argument(f'--{flag_name}')
 
         # Add any arguments that were added manually in add_arguments but aren't class variables (in order)
         for variable, (name_or_flags, kwargs) in self.argument_buffer.items():


### PR DESCRIPTION
As suggested [here](https://github.com/swansonk14/typed-argument-parser/pull/7#issuecomment-561262662), I'm sending a PR with another one of my changes.

With this PR, a flag definition like this:

```python
class Args(Tap):
    set_upstream: False
    force_with_lease: False
```

will result in the flag names `--set-upstream` and `--force-with-lease`. The attribute of the class (`set_upstream`) remain of course unchanged. I think flags with dashes just look much nicer than flags with underscores and using dashes is more wide-spread.

I didn't add tests because this PR is just meant as a suggestion, but you can try it out like this:

```python
from tap import Tap

class Args(Tap):
    arg_with_underscores: str

if __name__ == "__main__":
    args = Args(underscores_to_dashes=True).parse_args()
    print(args.arg_with_underscores)
```

`--help` outputs this:

```
usage: dash.py --arg-with-underscores ARG_WITH_UNDERSCORES [-h]

optional arguments:
  --arg-with-underscores ARG_WITH_UNDERSCORES
                        (str, required)
  -h, --help            show this help message and exit
```