### PR TITLE
Optionally require that bool flags are explicitly set to True or False

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -5,7 +5,7 @@ import json
 from pprint import pformat
 import sys
 import time
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Union, get_type_hints
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, TypeVar, Union, get_type_hints
 
 from tap.utils import get_class_variables, get_dest, get_git_root, get_git_url, has_git,has_uncommitted_changes,\
     is_option_arg, type_to_str, boolean_type
@@ -19,6 +19,8 @@ SUPPORTED_DEFAULT_COLLECTION_TYPES = SUPPORTED_DEFAULT_LIST_TYPES | SUPPORTED_DE
 SUPPORTED_DEFAULT_TYPES = set.union(SUPPORTED_DEFAULT_BASE_TYPES,
                                     SUPPORTED_DEFAULT_OPTIONAL_TYPES,
                                     SUPPORTED_DEFAULT_COLLECTION_TYPES)
+
+TapType = TypeVar('TapType', bound="Tap")
 
 
 class Tap(ArgumentParser):
@@ -204,9 +206,9 @@ class Tap(ArgumentParser):
 
         return arg_log
 
-    def parse_args(self,
+    def parse_args(self: TapType,
                    args: Optional[Sequence[str]] = None,
-                   known_only: bool = False) -> 'Tap':
+                   known_only: bool = False) -> TapType:
         """Parses arguments, sets attributes of self equal to the parsed arguments, and processes arguments.
 
         :param args: List of strings to parse. The default is taken from `sys.argv`.

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 from collections import OrderedDict
 import inspect
 from io import StringIO
@@ -192,3 +192,12 @@ def get_class_variables(cls: type) -> OrderedDict:
             break
 
     return variable_to_comment
+
+
+def boolean_type(flag_value: str):
+    """Convert a string to a boolean if it corresponds to 'True' or 'False'"""
+    if flag_value == "True":
+        return True
+    if flag_value == "False":
+        return False
+    raise ArgumentTypeError(f'Value has to be either "True" or "False".')


### PR DESCRIPTION
The final PR for my changes. (Previous was #8 )

With this PR (and with the feature turned on), boolean flags are specified like `--use_gpu True` or `--use_gpu False`. The advantage is that these flags can also be set explicitly to the default value.

So, in this example:

```python
from tap import Tap

class Args(Tap):
    use_gpu: bool = False
    drop_scale: bool = True

if __name__ == "__main__":
    args = Args(explicit_bool=True).parse_args()
    print(args)
```

We can specify `--use_gpu False` explicitly without having to care what the default value is. I know this style for bool flags is a bit unusual but I think it's better because it's more flexible and more explicit.

The help message looks like this:

```
usage: explicit.py [--use_gpu {True,False}] [--drop_scale {True,False}] [-h]

optional arguments:
  --use_gpu {True,False}
                        (bool, default=False)
  --drop_scale {True,False}
                        (bool, default=True)
  -h, --help            show this help message and exit
```

---

There is [another change in this PR](https://github.com/swansonk14/typed-argument-parser/commit/bfe719d52607a31e0324d042e98e005a7717f227) which I didn't want to put in a separate PR. It ensures that `.parse_args()` always returns the correct type even for subclasses of `Tap`.