### PR TITLE
Add an option to save without reproducibility

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -8,7 +8,6 @@ import time
 from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
 from typing_inspect import is_literal_type, get_args, get_origin, is_union_type
-from subprocess import CalledProcessError
 
 from tap.utils import (
     get_class_variables,
@@ -272,13 +271,12 @@ class Tap(ArgumentParser):
             'command_line': f'python {" ".join(sys.argv)}',
             'time': time.strftime('%c')
         }
-        try:
-            if has_git():
-                reproducibility['git_root'] = get_git_root()
-                reproducibility['git_url'] = get_git_url(commit_hash=True)
-                reproducibility['git_has_uncommitted_changes'] = has_uncommitted_changes()
-        except CalledProcessError:
-            pass
+        
+        if has_git():
+            reproducibility['git_root'] = get_git_root()
+            reproducibility['git_url'] = get_git_url(commit_hash=True)
+            reproducibility['git_has_uncommitted_changes'] = has_uncommitted_changes()
+
 
         return reproducibility
 

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -8,6 +8,7 @@ import time
 from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
 from typing_inspect import is_literal_type, get_args, get_origin, is_union_type
+from subprocess import CalledProcessError
 
 from tap.utils import (
     get_class_variables,
@@ -276,7 +277,7 @@ class Tap(ArgumentParser):
                 reproducibility['git_root'] = get_git_root()
                 reproducibility['git_url'] = get_git_url(commit_hash=True)
                 reproducibility['git_has_uncommitted_changes'] = has_uncommitted_changes()
-        except:
+        except CalledProcessError:
             pass
 
         return reproducibility

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -271,11 +271,13 @@ class Tap(ArgumentParser):
             'command_line': f'python {" ".join(sys.argv)}',
             'time': time.strftime('%c')
         }
-
-        if has_git():
-            reproducibility['git_root'] = get_git_root()
-            reproducibility['git_url'] = get_git_url(commit_hash=True)
-            reproducibility['git_has_uncommitted_changes'] = has_uncommitted_changes()
+        try:
+            if has_git():
+                reproducibility['git_root'] = get_git_root()
+                reproducibility['git_url'] = get_git_url(commit_hash=True)
+                reproducibility['git_has_uncommitted_changes'] = has_uncommitted_changes()
+        except:
+            pass
 
         return reproducibility
 
@@ -479,13 +481,16 @@ class Tap(ArgumentParser):
 
         self._parsed = True
 
-    def save(self, path: str) -> None:
+    def save(self, path: str, with_reproducibility: bool = True) -> None:
         """Saves the arguments and reproducibility information in JSON format, pickling what can't be encoded.
 
         :param path: Path to the JSON file where the arguments will be saved.
         """
         with open(path, 'w') as f:
-            json.dump(self._log_all(), f, indent=4, sort_keys=True, cls=PythonObjectEncoder)
+            if with_reproducibility:
+                json.dump(self._log_all(), f, indent=4, sort_keys=True, cls=PythonObjectEncoder)
+            else:
+                json.dump(self.as_dict(), f, indent=4, sort_keys=True, cls=PythonObjectEncoder)
 
     def load(self,
              path: str,

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -62,8 +62,11 @@ def get_git_url(commit_hash: bool = True) -> str:
     :return: The https url of the current git repo.
     """
     # Get git url (either https or ssh)
-    url = check_output(['git', 'remote', 'get-url', 'origin'])
-
+    try:
+        url = check_output(['git', 'remote', 'get-url', 'origin'])
+    except subprocess.CalledProcessError:
+        url = check_output(['git' 'config' '--get' 'remote.origin.url'])
+        
     # Remove .git at end
     url = url[:-len('.git')]
 


### PR DESCRIPTION
Hi,
I found that Tap().save() always saves with reproducibility info it is in a git repo.
However, this has two drawbacks:
1. Not everyone wants to save the reproducibility info.
2. In older versions of git (less than 2.0 I think) the code fails with an error.
I added two minor modifications which I hope you will accept.
1. Added a parameter to save: ```def save(self, path: str, with_reproducibility: bool = True)```
2. Added  a try/except around the git part to avoid code crash due to old git version