### PR TITLE
Add native support for pathlib.Path (fixes #32)

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -9,6 +9,7 @@ from warnings import warn
 from types import MethodType
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
 from typing_inspect import is_literal_type, get_args, get_origin, is_union_type
+from pathlib import Path
 
 from tap.utils import (
     get_class_variables,
@@ -33,10 +34,10 @@ from tap.utils import (
 # Constants
 EMPTY_TYPE = get_args(List)[0] if len(get_args(List)) > 0 else tuple()
 
-SUPPORTED_DEFAULT_BASE_TYPES = {str, int, float, bool}
-SUPPORTED_DEFAULT_OPTIONAL_TYPES = {Optional, Optional[str], Optional[int], Optional[float], Optional[bool]}
-SUPPORTED_DEFAULT_LIST_TYPES = {List, List[str], List[int], List[float], List[bool]}
-SUPPORTED_DEFAULT_SET_TYPES = {Set, Set[str], Set[int], Set[float], Set[bool]}
+SUPPORTED_DEFAULT_BASE_TYPES = {str, int, float, bool, Path}
+SUPPORTED_DEFAULT_OPTIONAL_TYPES = {Optional, Optional[str], Optional[int], Optional[float], Optional[bool], Optional[Path]}
+SUPPORTED_DEFAULT_LIST_TYPES = {List, List[str], List[int], List[float], List[bool], List[Path]}
+SUPPORTED_DEFAULT_SET_TYPES = {Set, Set[str], Set[int], Set[float], Set[bool], Set[Path]}
 SUPPORTED_DEFAULT_COLLECTION_TYPES = SUPPORTED_DEFAULT_LIST_TYPES | SUPPORTED_DEFAULT_SET_TYPES | {Tuple}
 SUPPORTED_DEFAULT_BOXED_TYPES = SUPPORTED_DEFAULT_OPTIONAL_TYPES | SUPPORTED_DEFAULT_COLLECTION_TYPES
 SUPPORTED_DEFAULT_TYPES = set.union(SUPPORTED_DEFAULT_BASE_TYPES,

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,5 +1,6 @@
 import sys
-from typing import List
+from pathlib import Path
+from typing import List, Set
 import unittest
 from unittest import TestCase
 
@@ -200,6 +201,15 @@ class TestArgparseActions(TestCase):
         args = ExtendListIntTap().parse_args('--arg 1 2 --arg 3 --arg 4 5'.split())
         self.assertEqual(args.arg, [0, 1, 2, 3, 4, 5])
 
+    @unittest.skipIf(sys.version_info < (3, 4), 'pathlib.Path introduced in Python 3.4')
+    def test_actions_path(self):
+        class ExtendPathTap(Tap):
+            arg: Path = []
+            arg2: Set[Path] = []
+
+        args = ExtendPathTap().parse_args('--arg 1.txt --arg2 2.txt 3.txt 2.txt'.split())
+        self.assertEqual(args.arg, Path("1.txt"))
+        self.assertEqual(args.arg2, {Path("2.txt"), Path("3.txt")})
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,14 +115,7 @@ class RequiredClassVariableTests(TestCase):
 class CrashesOnUnsupportedTypesTests(TestCase):
 
     def test_crashes_on_unsupported(self):
-        # From PiDelport: https://github.com/swansonk14/typed-argument-parser/issues/27
-        from pathlib import Path
-
-        class CrashingArgumentParser(Tap):
-            some_path: Path = 'some_path'
-
-        with self.assertRaises(ValueError):
-            CrashingArgumentParser().parse_args([])
+        pass
 
 
 class Person:


### PR DESCRIPTION
Here I add native support for pathlib.Path attributes on Tap classes.

It was made possible by adding:
`Path` to `SUPPORTED_DEFAULT_BASE_TYPES`,
`Optional[Path]` to `SUPPORTED_DEFAULT_OPTIONAL_TYPES`,
`List[Path]` to `SUPPORTED_DEFAULT_LIST_TYPES`, and
`Set[Path]` to `SUPPORTED_DEFAULT_SET_TYPES`