### PR TITLE
call process_args method in from_dict

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -578,7 +578,10 @@ class Tap(ArgumentParser):
                     raise AttributeError(f'Cannot set attribute "{key}" to "{value}". '
                                          f'To skip arguments that cannot be set \n'
                                          f'\t"skip_unsettable = True"')
-
+        
+        # Process args
+        self.process_args()
+        
         self._parsed = True
 
         return self


### PR DESCRIPTION
Solves https://github.com/swansonk14/typed-argument-parser/issues/41. The tests fail, but I can edit them later if this is actually the wanted behavior.