### PR TITLE
Fix action=append for List[Literal[...]]

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -191,7 +191,8 @@ class Tap(ArgumentParser):
                       and len(get_args(var_type)) > 0
                       and is_literal_type(get_args(var_type)[0])):
                     var_type, kwargs['choices'] = get_literals(get_args(var_type)[0], variable)
-                    kwargs['nargs'] = kwargs.get('nargs', '*')
+                    if kwargs.get('action') not in {'append', 'append_const'}:
+                        kwargs['nargs'] = kwargs.get('nargs', '*')
                 # Handle Tuple type (with type args) by extracting types of Tuple elements and enforcing them
                 elif get_origin(var_type) in (Tuple, tuple) and len(get_args(var_type)) > 0:
                     loop = False

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,5 +1,6 @@
 import sys
-from typing import List, Literal
+from typing import List
+from typing_extensions import Literal
 import unittest
 from unittest import TestCase
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List
+from typing import List, Literal
 import unittest
 from unittest import TestCase
 
@@ -98,6 +98,16 @@ class TestArgparseActions(TestCase):
 
         args = AppendListIntTap().parse_args('--arg 3 --arg 4'.split())
         self.assertEqual(args.arg, [1, 2, 3, 4])
+
+    def test_actions_append_list_literal(self):
+        class AppendListLiteralTap(Tap):
+            arg: List[Literal['what', 'is', 'up', 'today']] = ['what', 'is']
+
+            def configure(self):
+                self.add_argument('--arg', action='append')
+
+        args = AppendListLiteralTap().parse_args('--arg up --arg today'.split())
+        self.assertEqual(args.arg, 'what is up today'.split())
 
     def test_actions_append_untyped(self):
         class AppendListStrTap(Tap):


### PR DESCRIPTION
As with simple lists, do not default to `nargs='*'` if action is 'append', or the option will be parsed as a list of lists.

Before this change, the new test would fail, only passing if `Literal[...]` is replaced with `str`.
```
    def test_actions_append_list_literal(self):
        class AppendListLiteralTap(Tap):
            arg: List[Literal['what', 'is', 'up', 'today']] = ['what', 'is']
    
            def configure(self):
                self.add_argument('--arg', action='append')
    
        args = AppendListLiteralTap().parse_args('--arg up --arg today'.split())
>       self.assertEqual(args.arg, 'what is up today'.split())
E       AssertionError: Lists differ: ['what', 'is', ['up'], ['today']] != ['what', 'is', 'up', 'today']
E       
E       First differing element 2:
E       ['up']
E       'up'
E       
E       - ['what', 'is', ['up'], ['today']]
E       ?                -    -  -        -
E       
E       + ['what', 'is', 'up', 'today']
```