### PR TITLE
Support pre-processing config files with shlex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ class Args(Tap):
 args = Args(config_files=['my_config.txt']).parse_args()
 ```
 
-In addition, if `parse_config_files_with_shlex=True` is passed to `parse_args`, config files are passed using the python standard library `shlex.split` method, which supports shell-style string quoting, as well as comments with `#`.
+In addition, if `parse_config_files_with_shlex=True` is passed to `parse_args`, config files are pre-processed using the python standard library `shlex.split` method, which supports shell-style string quoting, as well as comments with `#`.
 
 For example, if you have the config file `my_config_shlex.txt`
 ```

--- a/README.md
+++ b/README.md
@@ -500,6 +500,6 @@ class Args(Tap):
     arg1: int
     arg2: str
 
-rgs = Args(config_files=['my_config_shlex.txt']).parse_args(parse_config_files_with_shlex=True)
+args = Args(config_files=['my_config_shlex.txt']).parse_args(parse_config_files_with_shlex=True)
 ```
 to get the resulting `args = {'arg1': 21, 'arg2': 'two three four'}`

--- a/README.md
+++ b/README.md
@@ -482,3 +482,24 @@ class Args(Tap):
 
 args = Args(config_files=['my_config.txt']).parse_args()
 ```
+
+In addition, if `parse_config_files_with_shlex=True` is passed to `parse_args`, config files are passed using the python standard library `shlex.split` method, which supports shell-style string quoting, as well as comments with `#`.
+
+For example, if you have the config file `my_config_shlex.txt`
+```
+--arg1 21 # Important arg value
+
+# Multi-word quoted string
+--arg2 "two three four"
+```
+then you can write
+```python
+from tap import Tap
+
+class Args(Tap):
+    arg1: int
+    arg2: str
+
+rgs = Args(config_files=['my_config_shlex.txt']).parse_args(parse_config_files_with_shlex=True)
+```
+to get the resulting `args = {'arg1': 21, 'arg2': 'two three four'}`

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -5,7 +5,7 @@ from functools import partial
 import json
 from pathlib import Path
 from pprint import pformat
-from shlex import quote
+from shlex import quote, split
 import sys
 import time
 from types import MethodType
@@ -384,7 +384,8 @@ class Tap(ArgumentParser):
 
     def parse_args(self: TapType,
                    args: Optional[Sequence[str]] = None,
-                   known_only: bool = False) -> TapType:
+                   known_only: bool = False,
+                   parse_config_files_with_shlex = False) -> TapType:
         """Parses arguments, sets attributes of self equal to the parsed arguments, and processes arguments.
 
         :param args: List of strings to parse. The default is taken from `sys.argv`.
@@ -397,7 +398,13 @@ class Tap(ArgumentParser):
             raise ValueError('parse_args can only be called once.')
 
         # Collect arguments from all of the configs
-        config_args = [arg for args_from_config in self.args_from_configs for arg in args_from_config.split()]
+
+        if parse_config_files_with_shlex:
+            splitter = lambda arg_string: split(arg_string, comments=True)
+        else:
+            splitter = lambda arg_string: arg_string.split()
+
+        config_args = [arg for args_from_config in self.args_from_configs for arg in splitter(args_from_config)]
 
         # Add config args at lower precedence and extract args from the command line if they are not passed explicitly
         args = config_args + (sys.argv[1:] if args is None else list(args))

--- a/tests/test_load_config_files.py
+++ b/tests/test_load_config_files.py
@@ -135,6 +135,23 @@ class LoadConfigFilesTests(TestCase):
 
             JunkConfigTap(config_files=[fname]).parse_args()
 
+    def test_shlex_config(self) -> None:
+        class ShlexConfigTap(Tap):
+            a: int
+            b: str
+
+        with TemporaryDirectory() as temp_dir:
+            fname = os.path.join(temp_dir, 'config.txt')
+
+            with open(fname, 'w') as f:
+                f.write('--a 21 # Important arg value\n\n# Multi-word quoted string\n--b "two three four"')
+
+            args = ShlexConfigTap(config_files=[fname]).parse_args(parse_config_files_with_shlex=True)
+
+        self.assertEqual(args.a, 21)
+        self.assertEqual(args.b, 'two three four')
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I find it useful to have the ability to use some common shlex-isms in my config files, namely quoted strings and comments.

This patch adds that facility if the user passes `parse_config_files_with_shlex` to `parse_args`.

I'm happy to make any requested aesthetic changes (parameter names, etc.).

The current implemented approach is programmatically backwards-compatible.