### PR TITLE
Union types in Python 3.10

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,13 +6,13 @@ jobs:
   run:
     runs-on: ubuntu-latest
     env:
-      PYTHON: '3.9'
+      PYTHON: '3.10'
     steps:
     - uses: actions/checkout@main
     - name: Setup Python
       uses: actions/setup-python@main
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Generate coverage report
       run: |
         git config --global user.email "you@example.com"

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@main
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Generate coverage report
       run: |
         git config --global user.email "you@example.com"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ Literal is analagous to argparse's [choices](https://docs.python.org/3/library/a
 More complex types _must_ be specified with the `type` keyword argument in `add_argument`, as in the example below.
 
 ```python
-def to_number(string: str):
+def to_number(string: str) -> Union[float, int]:
     return float(string) if '.' in string else int(string)
 
 class MyTap(Tap):
-    number: Union[int, float]
+    number: Union[float, int]
 
     def configure(self):
         self.add_argument('--number', type=to_number)

--- a/tap/__init__.py
+++ b/tap/__init__.py
@@ -1,4 +1,5 @@
+from argparse import ArgumentError, ArgumentTypeError
 from tap._version import __version__
 from tap.tap import Tap
 
-__all__ = ['Tap', '__version__']
+__all__ = ['ArgumentError', 'ArgumentTypeError', 'Tap', '__version__']

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -187,11 +187,13 @@ class Tap(ArgumentParser):
                         raise ArgumentTypeError(
                             'For Union types, you must include an explicit type function in the configure method. '
                             'For example,\n\n'
+                            'def to_number(string: str) -> Union[float, int]:\n'
+                            '    return float(string) if \'.\' in string else int(string)\n\n'
                             'class Args(Tap):\n'
-                            '    arg: Union[int, float]\n'
+                            '    arg: Union[float, int]\n'
                             '\n'
                             '    def configure(self) -> None:\n'
-                            '        self.add_argument("--arg", type=lambda x: float(x) if "." in x else int(x))'
+                            '        self.add_argument(\'--arg\', type=to_number)'
                         )
 
                     if len(var_args) > 0:

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -24,7 +24,7 @@ from typing import (
     Union,
 )
 from typing_extensions import Literal
-from typing_inspect import get_args, get_origin as typing_inspect_get_origin
+from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
 
 if sys.version_info >= (3, 10):
     from types import UnionType
@@ -487,3 +487,12 @@ def get_origin(tp: Any) -> Any:
         origin = UnionType
 
     return origin
+
+
+# TODO: remove this once typing_insepct.get_args is fixed for Python 3.10 union types
+def get_args(tp: Any) -> Tuple[type, ...]:
+    """Same as typing_inspect.get_args but fixes Python 3.10 union types."""
+    if sys.version_info >= (3, 10) and isinstance(tp, UnionType):
+        return tp.__args__
+
+    return typing_inspect_get_args(tp)

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 import tokenize
+from types import UnionType
 from typing import (
     Any,
     Callable,
@@ -471,7 +472,7 @@ def enforce_reproducibility(saved_reproducibility_data: Optional[Dict[str, str]]
                          f'in current args.')
 
 
-# TODO: remove this once typing_inspect.get_origin is fixed for Python 3.8 and 3.9
+# TODO: remove this once typing_inspect.get_origin is fixed for Python 3.8, 3.9, and 3.10
 # https://github.com/ilevkivskyi/typing_inspect/issues/64
 # https://github.com/ilevkivskyi/typing_inspect/issues/65
 def get_origin(tp: Any) -> Any:
@@ -480,5 +481,8 @@ def get_origin(tp: Any) -> Any:
 
     if origin is None:
         origin = tp
+
+    if isinstance(origin, UnionType):
+        origin = UnionType
 
     return origin

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentTypeError
 from collections import OrderedDict
 import json
 import os
@@ -297,7 +298,7 @@ class GetLiteralsTests(TestCase):
         self.assertEqual([literal_f(str(p)) for p in prims], literals)
 
     def test_get_literals_uniqueness(self) -> None:
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ArgumentTypeError):
             get_literals(Literal['two', 2, '2'], 'number')
 
     def test_get_literals_empty(self) -> None:


### PR DESCRIPTION
Support for the `|` operator in place of `Union` in Python 3.10. For example:

Using the `Union` operator in Python 3.6+

```python
from tap import Tap
from typing import Union

def to_number(string: str) -> Union[float, int]:
    return float(string) if '.' in string else int(string)

class Args(Tap):
    number: Union[float, int]

    def configure(self):
        self.add_argument('--number', type=to_number)

args = Args().parse_args()  
print(args.number)  # 7.0
```

Using the `|` operator in Python 3.10+

```python
from tap import Tap

def to_number(string: str) -> float | int:
    return float(string) if '.' in string else int(string)

class Args(Tap):
    number: float | int

    def configure(self):
        self.add_argument('--number', type=to_number)

args = Args().parse_args()
print(args.number)  # 7.0
```