### PR TITLE
feat: add support for single-quoted doc

### DIFF
--- a/tap/utils.py
+++ b/tap/utils.py
@@ -235,12 +235,21 @@ def get_class_variables(cls: type) -> OrderedDict:
             if token['token'].strip() == '':
                 continue
 
-            # Extract multiline comments
+            # Extract multiline comments in triple quote
             if (class_variable is not None
                     and token['token_type'] == tokenize.STRING
                     and token['token'][:3] in {'"""', "'''"}):
                 sep = ' ' if variable_to_comment[class_variable]['comment'] else ''
                 variable_to_comment[class_variable]['comment'] += sep + token['token'][3:-3].strip()
+                continue
+
+            # Extract multiline comments in single quote
+            if (class_variable is not None
+                    and token['token_type'] == tokenize.STRING
+                    and token['token'][:1] in {'"', "'"}):
+                sep = ' ' if variable_to_comment[class_variable]['comment'] else ''
+                variable_to_comment[class_variable]['comment'] += sep + token['token'][1:-1].strip()
+                continue
 
             # Match class variable
             class_variable = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -281,13 +281,30 @@ T
         class_variables['foo'] = {'comment': comment}
         self.assertEqual(get_class_variables(TrickyMultiline), class_variables)
 
-    def test_single_quote_multiline(self):
-        class SingleQuoteMultiline:
+    def test_triple_quote_multiline(self):
+        class TripleQuoteMultiline:
             bar: int = 0
             '''biz baz'''
 
+            hi: str
+            """Hello there"""
+
         class_variables = OrderedDict()
         class_variables['bar'] = {'comment': 'biz baz'}
+        class_variables['hi'] = {'comment': 'Hello there'}
+        self.assertEqual(get_class_variables(TripleQuoteMultiline), class_variables)
+
+    def test_single_quote_multiline(self):
+        class SingleQuoteMultiline:
+            bar: int = 0
+            'biz baz'
+
+            hi: str
+            "Hello there"
+
+        class_variables = OrderedDict()
+        class_variables['bar'] = {'comment': 'biz baz'}
+        class_variables['hi'] = {'comment': 'Hello there'}
         self.assertEqual(get_class_variables(SingleQuoteMultiline), class_variables)
 
     def test_functions_with_docs_multiline(self):


### PR DESCRIPTION
This PR fulfill #84 request to support single-quoted doc

With it

```python
# code.py
from pathlib import Path
from tap import Tap

class Args(Tap):
    db: Path
    "database file"

Args().parse_args()
```

gives

```
$ python code.py -h
usage: code.py --db DB [-h]

options:
  --db DB     (Path, required) database file
  -h, --help  show this help message and exit
```

Of course tell me if I need to change my MR, I'm still learning my way to contribute to open source project I like