### PR TITLE
Tapify: run functions via command line arguments + Python 3.11

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install pytest-cov
         pytest --cov=tap --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./coverage.xml

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,13 +6,13 @@ jobs:
   run:
     runs-on: ubuntu-latest
     env:
-      PYTHON: '3.10'
+      PYTHON: '3.11'
     steps:
     - uses: actions/checkout@main
     - name: Setup Python
       uses: actions/setup-python@main
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Generate coverage report
       run: |
         git config --global user.email "you@example.com"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@main
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set temp directories on Windows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         "Typing :: Typed"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     package_data={'tap': ['py.typed']},
     install_requires=[
         'typing_extensions >= 3.7.4',
-        'typing-inspect >= 0.7.1'
+        'typing-inspect >= 0.7.1',
+        'docstring-parser >= 0.15'
     ],
     tests_require=['pytest'],
     classifiers=[

--- a/tap/__init__.py
+++ b/tap/__init__.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentError, ArgumentTypeError
 from tap._version import __version__
-from tap.tap import Tap, tapify
+from tap.tap import Tap
+from tap.tapify import tapify
 
 __all__ = ['ArgumentError', 'ArgumentTypeError', 'Tap', 'tapify', '__version__']

--- a/tap/__init__.py
+++ b/tap/__init__.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentError, ArgumentTypeError
 from tap._version import __version__
-from tap.tap import Tap
+from tap.tap import Tap, tapify
 
-__all__ = ['ArgumentError', 'ArgumentTypeError', 'Tap', '__version__']
+__all__ = ['ArgumentError', 'ArgumentTypeError', 'Tap', 'tapify', '__version__']

--- a/tap/_version.py
+++ b/tap/_version.py
@@ -1,7 +1,7 @@
 __all__ = ['__version__']
 
 # major, minor, patch
-version_info = 1, 7, 3
+version_info = 1, 8, 0
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -39,7 +39,7 @@ def tapify(class_or_function: Union[Callable[[InputType], OutputType], OutputTyp
     param_to_description = {param.arg_name: param.description for param in docstring.params}
 
     # Create a Tap object
-    tap = Tap(description="\n".join(filter(None, (docstring.short_description, docstring.long_description))))
+    tap = Tap(description='\n'.join(filter(None, (docstring.short_description, docstring.long_description))))
 
     # Add arguments of class init or function to the Tap object
     for param_name, param in sig.parameters.items():

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -12,9 +12,8 @@ def tapify(function: Callable,
     """Runs a function by parsing arguments for the function from the command line.
 
     :param function: The function to run with the provided arguments.
-    :param args: Arguments to parse. If None, the arguments are parsed from the command line.
+    :param args: Arguments to parse. If None, arguments are parsed from the command line.
     :param known_only: If true, ignores extra arguments and only parses known arguments.
-                       Unparsed arguments are saved to self.extra_args.
     :param func_kwargs: Additional keyword arguments for the function. These act as default values when
                         parsing the command line arguments and overwrite the function defaults but
                         are overwritten by the parsed command line arguments.

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -1,0 +1,58 @@
+"""Tapify module, which can run a function by parsing arguments for the function from the command line."""
+from inspect import signature, Parameter
+from typing import Any, Callable, Optional
+
+from tap import Tap
+
+
+def tapify(function: Callable,
+           args: Optional[list[str]] = None,
+           known_only: bool = False,
+           **func_kwargs) -> Any:
+    """Runs a function by parsing arguments for the function from the command line.
+
+    :param function: The function to run with the provided arguments.
+    :param args: Arguments to parse. If None, the arguments are parsed from the command line.
+    :param known_only: If true, ignores extra arguments and only parses known arguments.
+                       Unparsed arguments are saved to self.extra_args.
+    :param func_kwargs: Additional keyword arguments for the function. These act as default values when
+                        parsing the command line arguments and overwrite the function defaults but
+                        are overwritten by the parsed command line arguments.
+    """
+    # Get signature from function
+    sig = signature(function)
+
+    # Create a Tap object with the arguments of the function
+    # TODO: get the help string from the function annotation
+    tap = Tap()
+    for param_name, param in sig.parameters.items():
+        tap_kwargs = {}
+
+        # Get type of the argument
+        if param.annotation != Parameter.empty:
+            tap._annotations[param.name] = param.annotation
+
+        # Get the default or required of the argument
+        if param.name in func_kwargs:
+            tap_kwargs['default'] = func_kwargs[param.name]
+            del func_kwargs[param.name]
+        elif param.default != Parameter.empty:
+            tap_kwargs['default'] = param.default
+        else:
+            tap_kwargs['required'] = True
+
+        # Add the argument to the Tap object
+        tap._add_argument(f'--{param_name}', **tap_kwargs)
+
+    # If any func_kwargs remain, they are not used in the function, so raise an error
+    if func_kwargs and not known_only:
+        raise ValueError(f'Unknown keyword arguments: {func_kwargs}')
+
+    # Parse command line arguments
+    args = tap.parse_args(
+        args=args,
+        known_only=known_only
+    )
+
+    # Run the function with the parsed arguments
+    return function(**args.as_dict())

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -1,12 +1,12 @@
 """Tapify module, which can run a function by parsing arguments for the function from the command line."""
 from inspect import signature, Parameter
-from typing import Any, Callable, Optional
+from typing import Any, Callable, List, Optional
 
 from tap import Tap
 
 
 def tapify(function: Callable,
-           args: Optional[list[str]] = None,
+           args: Optional[List[str]] = None,
            known_only: bool = False,
            **func_kwargs) -> Any:
     """Runs a function by parsing arguments for the function from the command line.

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -23,8 +23,7 @@ def tapify(function: Callable,
     sig = signature(function)
 
     # Create a Tap object with the arguments of the function
-    # TODO: get the help string from the function annotation
-    tap = Tap()
+    tap = Tap(description=function.__doc__)
     for param_name, param in sig.parameters.items():
         tap_kwargs = {}
 

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -39,7 +39,7 @@ def tapify(class_or_function: Union[Callable[[InputType], OutputType], OutputTyp
     param_to_description = {param.arg_name: param.description for param in docstring.params}
 
     # Create a Tap object
-    tap = Tap(description=f'{docstring.short_description}\n{docstring.long_description}')
+    tap = Tap(description="\n".join(filter(None, (docstring.short_description, docstring.long_description))))
 
     # Add arguments of class init or function to the Tap object
     for param_name, param in sig.parameters.items():

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -220,7 +220,7 @@ class TestArgparseActions(TestCase):
 
         help_regex = r'.*positional arguments:\n.*arg\s*\(str, required\).*'
         help_text = PositionalDefault().format_help()
-        self.assertRegexpMatches(help_text, help_regex)
+        self.assertRegex(help_text, help_regex)
 
 
 if __name__ == '__main__':

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,6 +13,15 @@ from unittest import TestCase
 from tap import Tap
 
 
+# Suppress prints from SystemExit
+class DevNull:
+    def write(self, msg):
+        pass
+
+
+sys.stderr = DevNull()
+
+
 def stringify(arg_list: Iterable[Any]) -> List[str]:
     """Converts an iterable of arguments of any type to a list of strings.
 
@@ -96,22 +105,14 @@ class RequiredClassVariableTests(TestCase):
 
         self.tap = RequiredArgumentsParser()
 
-        # Suppress prints from SystemExit
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_arg_str_required(self):
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             self.tap.parse_args([
                 '--arg_str_required', 'tappy',
             ])
 
     def test_arg_list_str_required(self):
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             self.tap.parse_args([
                 '--arg_list_str_required', 'hi', 'there',
             ])
@@ -553,10 +554,8 @@ class LiteralCrashTests(TestCase):
         class DevNull:
             def write(self, msg):
                 pass
-        self.dev_null = DevNull()
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             LiteralCrashTap().parse_args(['--arg_lit', '123'])
 
 
@@ -741,13 +740,6 @@ class UnionTypeTests(TestCase):
 
 
 class AddArgumentTests(TestCase):
-    def setUp(self) -> None:
-        # Suppress prints from SystemExit
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_positional(self) -> None:
         class AddArgumentPositionalTap(IntegrationDefaultTap):
             def configure(self) -> None:
@@ -928,7 +920,6 @@ class AddArgumentTests(TestCase):
         arg_list_str = ['hi', 'there', 'person', '123']
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             AddArgumentConflictingNargsTap().parse_args(['--arg_list_str', *arg_list_str])
 
     def test_repeat_action(self) -> None:
@@ -1049,22 +1040,14 @@ class ParseExplicitBoolArgsTests(TestCase):
 
         self.test_bool_cases = test_bool_cases
 
-        # Suppress prints from SystemExit
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_explicit_bool(self):
         class ExplicitBoolTap(Tap):
             is_gpu: bool
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             ExplicitBoolTap(explicit_bool=True).parse_args(['--is_gpu'])
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             ExplicitBoolTap(explicit_bool=True).parse_args([])
 
         self.test_bool_cases(ExplicitBoolTap)
@@ -1094,12 +1077,6 @@ class SetTests(TestCase):
 
 
 class TupleTests(TestCase):
-    def setUp(self) -> None:
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_tuple_empty(self):
         tup_arg = ('three', 'four', 'ten')
         tup_default_arg = (1, 2, '5')
@@ -1205,7 +1182,6 @@ class TupleTests(TestCase):
             tup: Tuple[int]
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             TupleTapTypeFails().parse_args(['--tup', 'tomato'])
 
     def test_tuple_wrong_num_args_fails(self):
@@ -1213,7 +1189,6 @@ class TupleTests(TestCase):
             tup: Tuple[int]
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             TupleTapArgsFails().parse_args(['--tup', '1', '1'])
 
     def test_tuple_wrong_order_fails(self):
@@ -1221,7 +1196,6 @@ class TupleTests(TestCase):
             tup: Tuple[int, str]
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             TupleTapOrderFails().parse_args(['--tup', 'seven', '1'])
 
     def test_empty_tuple_fails(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1224,10 +1224,15 @@ class TupleTests(TestCase):
 
     def test_empty_tuple_fails(self):
         class EmptyTupleTap(Tap):
-            tup: Tuple[()]
+            tup_str: Tuple[()]
 
-        with self.assertRaises(ArgumentTypeError):
-            EmptyTupleTap().parse_args([])
+        arg_str = ('hi there', 'hello hi bye')
+
+        args = EmptyTupleTap().parse_args([
+            '--tup_str', *arg_str,
+        ])
+
+        self.assertEqual(args.tup_str, arg_str)
 
     def test_tuple_non_tuple_default(self):
         class TupleNonTupleTap(Tap):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 import os
 from pathlib import Path
 import pickle
-from re import L
 import sys
 from tempfile import TemporaryDirectory
 from typing import Any, Iterable, List, Optional, Set, Tuple, Union
@@ -24,7 +23,8 @@ def stringify(arg_list: Iterable[Any]) -> List[str]:
 
 
 class EdgeCaseTests(TestCase):
-    def test_empty(self) -> None:
+    @staticmethod
+    def test_empty() -> None:
         class EmptyTap(Tap):
             pass
 
@@ -124,8 +124,10 @@ class RequiredClassVariableTests(TestCase):
         self.assertEqual(args.arg_str_required, 'tappy')
         self.assertEqual(args.arg_list_str_required, ['hi', 'there'])
 
+
 class ParameterizedStandardCollectionTests(TestCase):
-    @unittest.skipIf(sys.version_info < (3, 9), 'Parameterized standard collections (e.g., list[int]) introduced in Python 3.9')
+    @unittest.skipIf(sys.version_info < (3, 9),
+                     'Parameterized standard collections (e.g., list[int]) introduced in Python 3.9')
     def test_parameterized_standard_collection(self):
         class ParameterizedStandardCollectionTap(Tap):
             arg_list_str: list[str]

--- a/tests/test_load_config_files.py
+++ b/tests/test_load_config_files.py
@@ -7,14 +7,16 @@ from unittest import TestCase
 from tap import Tap
 
 
+# Suppress prints from SystemExit
+class DevNull:
+    def write(self, msg):
+        pass
+
+
+sys.stderr = DevNull()
+
+
 class LoadConfigFilesTests(TestCase):
-
-    def setUp(self) -> None:
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_file_does_not_exist(self) -> None:
         class EmptyTap(Tap):
             pass
@@ -77,7 +79,6 @@ class LoadConfigFilesTests(TestCase):
             b: str = 'b'
 
         with TemporaryDirectory() as temp_dir, self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             fname = os.path.join(temp_dir, 'config.txt')
 
             with open(fname, 'w') as f:
@@ -127,7 +128,6 @@ class LoadConfigFilesTests(TestCase):
             b: str = 'b'
 
         with TemporaryDirectory() as temp_dir, self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
             fname = os.path.join(temp_dir, 'config.txt')
 
             with open(fname, 'w') as f:

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentError
 import sys
 from typing import Union
 from typing_extensions import Literal
@@ -111,14 +112,19 @@ class TestSubparser(TestCase):
                 self.add_subparser('a', SubparserB)
                 self.add_subparser('a', SubparserA)
 
-        args = Args().parse_args('a --bar 2'.split())
-        self.assertFalse(args.foo)
-        self.assertEqual(args.bar, 2)
-        self.assertFalse(hasattr(args, 'baz'))
-
         sys.stderr = self.dev_null
-        with self.assertRaises(SystemExit):
-            Args().parse_args('a --baz 2'.split())
+
+        if sys.version_info >= (3, 11):
+            with self.assertRaises(ArgumentError):
+                Args().parse_args([])
+        else:
+            args = Args().parse_args('a --bar 2'.split())
+            self.assertFalse(args.foo)
+            self.assertEqual(args.bar, 2)
+            self.assertFalse(hasattr(args, 'baz'))
+
+            with self.assertRaises(SystemExit):
+                Args().parse_args('a --baz 2'.split())
 
     def test_add_subparsers_twice(self):
         class SubparserA(Tap):

--- a/tests/test_subparser.py
+++ b/tests/test_subparser.py
@@ -8,15 +8,16 @@ from unittest import TestCase
 from tap import Tap
 
 
+# Suppress prints from SystemExit
+class DevNull:
+    def write(self, msg):
+        pass
+
+
+sys.stderr = DevNull()
+
+
 class TestSubparser(TestCase):
-
-    def setUp(self) -> None:
-        # Suppress prints from SystemExit
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_subparser_documentation_example(self):
         class SubparserA(Tap):
             bar: int  # bar help
@@ -51,8 +52,6 @@ class TestSubparser(TestCase):
         self.assertTrue(args.foo)
         self.assertFalse(hasattr(args, 'bar'))
         self.assertEqual(args.baz, 'X')
-
-        sys.stderr = self.dev_null
 
         with self.assertRaises(SystemExit):
             Args().parse_args('--baz X --foo b'.split())
@@ -112,8 +111,6 @@ class TestSubparser(TestCase):
                 self.add_subparser('a', SubparserB)
                 self.add_subparser('a', SubparserA)
 
-        sys.stderr = self.dev_null
-
         if sys.version_info >= (3, 11):
             with self.assertRaises(ArgumentError):
                 Args().parse_args([])
@@ -138,7 +135,6 @@ class TestSubparser(TestCase):
                 self.add_subparsers(help='sub-command1 help')
                 self.add_subparsers(help='sub-command2 help')
 
-        sys.stderr = self.dev_null
         with self.assertRaises(SystemExit):
             Args().parse_args([])
 

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1,0 +1,200 @@
+import sys
+from typing import Any, Optional, Tuple
+import unittest
+from unittest import TestCase
+
+from tap import tapify
+
+
+class Person:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self) -> str:
+        return f'Person({self.name})'
+
+
+class Problems:
+    def __init__(self, problem_1: str, problem_2):
+        self.problem_1 = problem_1
+        self.problem_2 = problem_2
+
+    def __str__(self) -> str:
+        return f'Problems({self.problem_1}, {self.problem_2})'
+
+
+class TapifyTests(TestCase):
+    def setUp(self) -> None:
+        # Suppress prints from SystemExit
+        class DevNull:
+            def write(self, msg):
+                pass
+        self.dev_null = DevNull()
+
+    def test_tapify_empty(self):
+        def pie() -> float:
+            return 3.14
+
+        self.assertEqual(tapify(pie, args=[]), 3.14)
+
+    def test_tapify_simple_types(self):
+        def concat(a: int, simple: str, test: float, of: float, types: bool) -> str:
+            return f'{a} {simple} {test} {of} {types}'
+
+        output = tapify(concat, args=[
+            '--a', '1',
+            '--simple', 'simple',
+            '--test', '3.14',
+            '--of', '2.718',
+            '--types'
+        ])
+
+        self.assertEqual(output, '1 simple 3.14 2.718 True')
+
+    def test_tapify_simple_types_defaults(self):
+        def concat(a: int, simple: str, test: float, of: float = -.3, types: bool = False, wow: str = 'abc') -> str:
+            return f'{a} {simple} {test} {of} {types} {wow}'
+
+        output = tapify(concat, args=[
+            '--a', '1',
+            '--simple', 'simple',
+            '--test', '3.14',
+            '--types',
+            '--wow', 'wee'
+        ])
+
+        self.assertEqual(output, '1 simple 3.14 -0.3 True wee')
+
+    def test_tapify_complex_types(self):
+        def concat(complexity: list[str], requires: tuple[int, int], intelligence: Person) -> str:
+            return f'{" ".join(complexity)} {requires[0]} {requires[1]} {intelligence}'
+
+        output = tapify(concat, args=[
+            '--complexity', 'complex', 'things', 'require',
+            '--requires', '1', '0',
+            '--intelligence', 'jesse',
+        ])
+
+        self.assertEqual(output, 'complex things require 1 0 Person(jesse)')
+
+    def test_tapify_complex_types_defaults(self):
+        def concat(complexity: list[str],
+                   requires: Tuple[int, int] = (2, 5),
+                   intelligence: Person = Person('kyle'),
+                   maybe: Optional[str] = None,
+                   possibly: Optional[str] = None) -> str:
+            return f'{" ".join(complexity)} {requires[0]} {requires[1]} {intelligence} {maybe} {possibly}'
+
+        output = tapify(concat, args=[
+            '--complexity', 'complex', 'things', 'require',
+            '--requires', '-3', '12',
+            '--possibly', 'huh?'
+        ])
+
+        self.assertEqual(output, 'complex things require -3 12 Person(kyle) None huh?')
+
+    def test_tapify_too_few_args(self):
+        def concat(so: int, many: float, args: str) -> str:
+            return f'{so} {many} {args}'
+
+        with self.assertRaises(SystemExit):
+            sys.stderr = self.dev_null
+
+            tapify(concat, args=[
+                '--so', '23',
+                '--many', '9.3'
+            ])
+
+    def test_tapify_too_many_args(self):
+        def concat(so: int, few: float) -> str:
+            return f'{so} {few}'
+
+        with self.assertRaises(SystemExit):
+            sys.stderr = self.dev_null
+
+            tapify(concat, args=[
+                '--so', '23',
+                '--few', '9.3',
+                '--args', 'wow'
+            ])
+
+    def test_tapify_too_many_args_known_only(self):
+        def concat(so: int, few: float) -> str:
+            return f'{so} {few}'
+
+        output = tapify(concat, args=[
+            '--so', '23',
+            '--few', '9.3',
+            '--args', 'wow'
+        ], known_only=True)
+
+        self.assertEqual(output, '23 9.3')
+
+    def test_tapify_kwargs(self):
+        def concat(i: int, like: float, k: int, w: str = 'w', args: str = 'argy', always: bool = False) -> str:
+            return f'{i} {like} {k} {w} {args} {always}'
+
+        output = tapify(concat, args=[
+            '--i', '23',
+            '--args', 'wow',
+            '--mis', 'direction',
+            '--like', '3.03',
+        ], known_only=True, w='hello', k=5, like=3.4, extra='arg')
+
+        self.assertEqual(output, '23 3.03 5 hello wow False')
+
+    def test_tapify_kwargs_extra(self):
+        def concat(i: int, like: float, k: int, w: str = 'w', args: str = 'argy', always: bool = False) -> str:
+            return f'{i} {like} {k} {w} {args} {always}'
+
+        with self.assertRaises(ValueError):
+            sys.stderr = self.dev_null
+
+            tapify(concat, args=[
+                '--i', '23',
+                '--args', 'wow',
+                '--like', '3.03',
+            ], w='hello', k=5, like=3.4, mis='direction')
+
+    def test_tapify_unsupported_type(self):
+        def concat(problems: Problems) -> str:
+            return f'{problems}'
+
+        output = tapify(concat, args=[], problems=Problems('oh', 'no!'))
+
+        self.assertEqual(output, 'Problems(oh, no!)')
+
+        with self.assertRaises(SystemExit):
+            sys.stderr = self.dev_null
+
+            tapify(concat, args=['--problems', '1', '2'])
+
+    def test_tapify_untyped(self):
+        def concat(untyped_1, typed_1: int,
+                   untyped_2=5, typed_2: str = 'now',
+                   untyped_3='hi', typed_3: bool = False) -> str:
+            return f'{untyped_1} {typed_1} {untyped_2} {typed_2} {untyped_3} {typed_3}'
+
+        output = tapify(concat, args=[
+            '--untyped_1', 'why not type?',
+            '--typed_1', '1',
+            '--typed_2', 'typing is great!',
+            '--untyped_3', 'bye'
+        ])
+
+        self.assertEqual(output, 'why not type? 1 5 typing is great! bye False')
+
+# Supported argument types
+# Unsupported types
+# Too many arguments
+# Not enough arguments
+# Some from command line and some from code providing it to the function
+# All arguments from code providing it to the function (just enough, too many, too few)
+# With and without defaults
+# Untyped
+
+# Help string
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -8,6 +8,15 @@ from unittest import TestCase
 from tap import tapify
 
 
+# Suppress prints from SystemExit
+class DevNull:
+    def write(self, msg):
+        pass
+
+
+sys.stderr = DevNull()
+
+
 class Person:
     def __init__(self, name: str):
         self.name = name
@@ -26,13 +35,6 @@ class Problems:
 
 
 class TapifyTests(TestCase):
-    def setUp(self) -> None:
-        # Suppress prints from SystemExit
-        class DevNull:
-            def write(self, msg):
-                pass
-        self.dev_null = DevNull()
-
     def test_tapify_empty(self):
         def pie() -> float:
             return 3.14
@@ -100,8 +102,6 @@ class TapifyTests(TestCase):
             return f'{so} {many} {args}'
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
-
             tapify(concat, args=[
                 '--so', '23',
                 '--many', '9.3'
@@ -112,8 +112,6 @@ class TapifyTests(TestCase):
             return f'{so} {few}'
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
-
             tapify(concat, args=[
                 '--so', '23',
                 '--few', '9.3',
@@ -150,8 +148,6 @@ class TapifyTests(TestCase):
             return f'{i} {like} {k} {w} {args} {always}'
 
         with self.assertRaises(ValueError):
-            sys.stderr = self.dev_null
-
             tapify(concat, args=[
                 '--i', '23',
                 '--args', 'wow',
@@ -167,8 +163,6 @@ class TapifyTests(TestCase):
         self.assertEqual(output, 'Problems(oh, no!)')
 
         with self.assertRaises(SystemExit):
-            sys.stderr = self.dev_null
-
             tapify(concat, args=['--problems', '1', '2'])
 
     def test_tapify_untyped(self):
@@ -191,14 +185,9 @@ class TapifyTests(TestCase):
             """Concatenate three numbers."""
             return f'{a} {b} {c}'
 
-        sys.stderr = self.dev_null
-        sys.stdout = self.dev_null
-
         f = io.StringIO()
         with contextlib.redirect_stdout(f):
             with self.assertRaises(SystemExit):
-                sys.stderr = self.dev_null
-
                 tapify(concat, args=['-h'])
 
         self.assertIn('Concatenate three numbers.', f.getvalue())

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1,7 +1,8 @@
 import contextlib
+from dataclasses import dataclass
 import io
 import sys
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Any
 import unittest
 from unittest import TestCase
 
@@ -39,47 +40,113 @@ class TapifyTests(TestCase):
         def pie() -> float:
             return 3.14
 
-        self.assertEqual(tapify(pie, args=[]), 3.14)
+        class Pie:
+            def __eq__(self, other: float) -> bool:
+                return other == pie()
+
+        @dataclass
+        class PieDataclass:
+            def __eq__(self, other: float) -> bool:
+                return other == pie()
+
+        for class_or_function in [pie, Pie, PieDataclass]:
+            self.assertEqual(tapify(class_or_function, args=[]), 3.14)
 
     def test_tapify_simple_types(self):
         def concat(a: int, simple: str, test: float, of: float, types: bool) -> str:
             return f'{a} {simple} {test} {of} {types}'
 
-        output = tapify(concat, args=[
-            '--a', '1',
-            '--simple', 'simple',
-            '--test', '3.14',
-            '--of', '2.718',
-            '--types'
-        ])
+        class Concat:
+            def __init__(self, a: int, simple: str, test: float, of: float, types: bool):
+                self.kwargs = {'a': a, 'simple': simple, 'test': test, 'of': of, 'types': types}
 
-        self.assertEqual(output, '1 simple 3.14 2.718 True')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            a: int
+            simple: str
+            test: float
+            of: float
+            types: bool
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.a, self.simple, self.test, self.of, self.types)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--a', '1',
+                '--simple', 'simple',
+                '--test', '3.14',
+                '--of', '2.718',
+                '--types'
+            ])
+
+            self.assertEqual(output, '1 simple 3.14 2.718 True')
 
     def test_tapify_simple_types_defaults(self):
         def concat(a: int, simple: str, test: float, of: float = -.3, types: bool = False, wow: str = 'abc') -> str:
             return f'{a} {simple} {test} {of} {types} {wow}'
 
-        output = tapify(concat, args=[
-            '--a', '1',
-            '--simple', 'simple',
-            '--test', '3.14',
-            '--types',
-            '--wow', 'wee'
-        ])
+        class Concat:
+            def __init__(self, a: int, simple: str, test: float, of: float = -.3, types: bool = False, wow: str = 'abc'):
+                self.kwargs = {'a': a, 'simple': simple, 'test': test, 'of': of, 'types': types, 'wow': wow}
 
-        self.assertEqual(output, '1 simple 3.14 -0.3 True wee')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            a: int
+            simple: str
+            test: float
+            of: float = -.3
+            types: bool = False
+            wow: str = 'abc'
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.a, self.simple, self.test, self.of, self.types, self.wow)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--a', '1',
+                '--simple', 'simple',
+                '--test', '3.14',
+                '--types',
+                '--wow', 'wee'
+            ])
+
+            self.assertEqual(output, '1 simple 3.14 -0.3 True wee')
 
     def test_tapify_complex_types(self):
         def concat(complexity: List[str], requires: Tuple[int, int], intelligence: Person) -> str:
             return f'{" ".join(complexity)} {requires[0]} {requires[1]} {intelligence}'
 
-        output = tapify(concat, args=[
-            '--complexity', 'complex', 'things', 'require',
-            '--requires', '1', '0',
-            '--intelligence', 'jesse',
-        ])
+        class Concat:
+            def __init__(self, complexity: List[str], requires: Tuple[int, int], intelligence: Person):
+                self.kwargs = {'complexity': complexity, 'requires': requires, 'intelligence': intelligence}
 
-        self.assertEqual(output, 'complex things require 1 0 Person(jesse)')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            complexity: List[str]
+            requires: Tuple[int, int]
+            intelligence: Person
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.complexity, self.requires, self.intelligence)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--complexity', 'complex', 'things', 'require',
+                '--requires', '1', '0',
+                '--intelligence', 'jesse',
+            ])
+
+            self.assertEqual(output, 'complex things require 1 0 Person(jesse)')
 
     @unittest.skipIf(sys.version_info < (3, 9),
                      'Parameterized standard collections (e.g., list[int]) introduced in Python 3.9')
@@ -87,13 +154,30 @@ class TapifyTests(TestCase):
         def concat(complexity: list[int], requires: tuple[int, int], intelligence: Person) -> str:
             return f'{" ".join(map(str, complexity))} {requires[0]} {requires[1]} {intelligence}'
 
-        output = tapify(concat, args=[
-            '--complexity', '1', '2', '3',
-            '--requires', '1', '0',
-            '--intelligence', 'jesse',
-        ])
+        class Concat:
+            def __init__(self, complexity: list[int], requires: tuple[int, int], intelligence: Person):
+                self.kwargs = {'complexity': complexity, 'requires': requires, 'intelligence': intelligence}
 
-        self.assertEqual(output, '1 2 3 1 0 Person(jesse)')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            complexity: list[int]
+            requires: tuple[int, int]
+            intelligence: Person
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.complexity, self.requires, self.intelligence)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--complexity', '1', '2', '3',
+                '--requires', '1', '0',
+                '--intelligence', 'jesse',
+            ])
+
+            self.assertEqual(output, '1 2 3 1 0 Person(jesse)')
 
     def test_tapify_complex_types_defaults(self):
         def concat(complexity: List[str],
@@ -103,81 +187,208 @@ class TapifyTests(TestCase):
                    possibly: Optional[str] = None) -> str:
             return f'{" ".join(complexity)} {requires[0]} {requires[1]} {intelligence} {maybe} {possibly}'
 
-        output = tapify(concat, args=[
-            '--complexity', 'complex', 'things', 'require',
-            '--requires', '-3', '12',
-            '--possibly', 'huh?'
-        ])
+        class Concat:
+            def __init__(self, complexity: List[str],
+                         requires: Tuple[int, int] = (2, 5),
+                         intelligence: Person = Person('kyle'),
+                         maybe: Optional[str] = None,
+                         possibly: Optional[str] = None):
+                self.kwargs = {'complexity': complexity, 'requires': requires, 'intelligence': intelligence,
+                               'maybe': maybe, 'possibly': possibly}
 
-        self.assertEqual(output, 'complex things require -3 12 Person(kyle) None huh?')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            complexity: List[str]
+            requires: Tuple[int, int] = (2, 5)
+            intelligence: Person = Person('kyle')
+            maybe: Optional[str] = None
+            possibly: Optional[str] = None
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.complexity, self.requires, self.intelligence, self.maybe, self.possibly)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--complexity', 'complex', 'things', 'require',
+                '--requires', '-3', '12',
+                '--possibly', 'huh?'
+            ])
+
+            self.assertEqual(output, 'complex things require -3 12 Person(kyle) None huh?')
 
     def test_tapify_too_few_args(self):
         def concat(so: int, many: float, args: str) -> str:
             return f'{so} {many} {args}'
 
-        with self.assertRaises(SystemExit):
-            tapify(concat, args=[
-                '--so', '23',
-                '--many', '9.3'
-            ])
+        class Concat:
+            def __init__(self, so: int, many: float, args: str):
+                self.kwargs = {'so': so, 'many': many, 'args': args}
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            so: int
+            many: float
+            args: str
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.so, self.many, self.args)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            with self.assertRaises(SystemExit):
+                tapify(class_or_function, args=[
+                    '--so', '23',
+                    '--many', '9.3'
+                ])
 
     def test_tapify_too_many_args(self):
         def concat(so: int, few: float) -> str:
             return f'{so} {few}'
 
-        with self.assertRaises(SystemExit):
-            tapify(concat, args=[
-                '--so', '23',
-                '--few', '9.3',
-                '--args', 'wow'
-            ])
+        class Concat:
+            def __init__(self, so: int, few: float):
+                self.kwargs = {'so': so, 'few': few}
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            so: int
+            few: float
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.so, self.few)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            with self.assertRaises(SystemExit):
+                tapify(class_or_function, args=[
+                    '--so', '23',
+                    '--few', '9.3',
+                    '--args', 'wow'
+                ])
 
     def test_tapify_too_many_args_known_only(self):
         def concat(so: int, few: float) -> str:
             return f'{so} {few}'
 
-        output = tapify(concat, args=[
-            '--so', '23',
-            '--few', '9.3',
-            '--args', 'wow'
-        ], known_only=True)
+        class Concat:
+            def __init__(self, so: int, few: float):
+                self.kwargs = {'so': so, 'few': few}
 
-        self.assertEqual(output, '23 9.3')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            so: int
+            few: float
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.so, self.few)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--so', '23',
+                '--few', '9.3',
+                '--args', 'wow'
+            ], known_only=True)
+
+            self.assertEqual(output, '23 9.3')
 
     def test_tapify_kwargs(self):
         def concat(i: int, like: float, k: int, w: str = 'w', args: str = 'argy', always: bool = False) -> str:
             return f'{i} {like} {k} {w} {args} {always}'
 
-        output = tapify(concat, args=[
-            '--i', '23',
-            '--args', 'wow',
-            '--mis', 'direction',
-            '--like', '3.03',
-        ], known_only=True, w='hello', k=5, like=3.4, extra='arg')
+        class Concat:
+            def __init__(self, i: int, like: float, k: int, w: str = 'w', args: str = 'argy', always: bool = False):
+                self.kwargs = {'i': i, 'like': like, 'k': k, 'w': w, 'args': args, 'always': always}
 
-        self.assertEqual(output, '23 3.03 5 hello wow False')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            i: int
+            like: float
+            k: int
+            w: str = 'w'
+            args: str = 'argy'
+            always: bool = False
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.i, self.like, self.k, self.w, self.args, self.always)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--i', '23',
+                '--args', 'wow',
+                '--like', '3.03',
+            ], known_only=True, w='hello', k=5, like=3.4, extra='arg')
+
+            self.assertEqual(output, '23 3.03 5 hello wow False')
 
     def test_tapify_kwargs_extra(self):
         def concat(i: int, like: float, k: int, w: str = 'w', args: str = 'argy', always: bool = False) -> str:
             return f'{i} {like} {k} {w} {args} {always}'
 
-        with self.assertRaises(ValueError):
-            tapify(concat, args=[
-                '--i', '23',
-                '--args', 'wow',
-                '--like', '3.03',
-            ], w='hello', k=5, like=3.4, mis='direction')
+        class Concat:
+            def __init__(self, i: int, like: float, k: int, w: str = 'w', args: str = 'argy', always: bool = False):
+                self.kwargs = {'i': i, 'like': like, 'k': k, 'w': w, 'args': args, 'always': always}
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            i: int
+            like: float
+            k: int
+            w: str = 'w'
+            args: str = 'argy'
+            always: bool = False
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.i, self.like, self.k, self.w, self.args, self.always)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            with self.assertRaises(ValueError):
+                tapify(class_or_function, args=[
+                    '--i', '23',
+                    '--args', 'wow',
+                    '--like', '3.03',
+                ], w='hello', k=5, like=3.4, mis='direction')
 
     def test_tapify_unsupported_type(self):
         def concat(problems: Problems) -> str:
             return f'{problems}'
 
-        output = tapify(concat, args=[], problems=Problems('oh', 'no!'))
+        class Concat:
+            def __init__(self, problems: Problems):
+                self.problems = problems
 
-        self.assertEqual(output, 'Problems(oh, no!)')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.problems)
 
-        with self.assertRaises(SystemExit):
-            tapify(concat, args=['--problems', '1', '2'])
+        @dataclass
+        class ConcatDataclass:
+            problems: Problems
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.problems)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[], problems=Problems('oh', 'no!'))
+
+            self.assertEqual(output, 'Problems(oh, no!)')
+
+            with self.assertRaises(SystemExit):
+                tapify(class_or_function, args=['--problems', '1', '2'])
 
     def test_tapify_untyped(self):
         def concat(untyped_1, typed_1: int,
@@ -185,37 +396,140 @@ class TapifyTests(TestCase):
                    untyped_3='hi', typed_3: bool = False) -> str:
             return f'{untyped_1} {typed_1} {untyped_2} {typed_2} {untyped_3} {typed_3}'
 
-        output = tapify(concat, args=[
-            '--untyped_1', 'why not type?',
-            '--typed_1', '1',
-            '--typed_2', 'typing is great!',
-            '--untyped_3', 'bye'
-        ])
+        class Concat:
+            def __init__(self, untyped_1, typed_1: int,
+                         untyped_2=5, typed_2: str = 'now',
+                         untyped_3='hi', typed_3: bool = False):
+                self.kwargs = {'untyped_1': untyped_1, 'typed_1': typed_1,
+                               'untyped_2': untyped_2, 'typed_2': typed_2,
+                               'untyped_3': untyped_3, 'typed_3': typed_3}
 
-        self.assertEqual(output, 'why not type? 1 5 typing is great! bye False')
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
 
-    def test_tapify_help(self):
-        def concat(a: int, b: int, c: int) -> str:
-            """Concatenate three numbers."""
-            return f'{a} {b} {c}'
+        @dataclass
+        class ConcatDataclass:
+            untyped_1: Any
+            typed_1: int
+            untyped_2: Any = 5
+            typed_2: str = 'now'
+            untyped_3: Any = 'hi'
+            typed_3: bool = False
 
-        f = io.StringIO()
-        with contextlib.redirect_stdout(f):
-            with self.assertRaises(SystemExit):
-                tapify(concat, args=['-h'])
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.untyped_1, self.typed_1,
+                                       self.untyped_2, self.typed_2,
+                                       self.untyped_3, self.typed_3)
 
-        self.assertIn('Concatenate three numbers.', f.getvalue())
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output = tapify(class_or_function, args=[
+                '--untyped_1', 'why not type?',
+                '--typed_1', '1',
+                '--typed_2', 'typing is great!',
+                '--untyped_3', 'bye'
+            ])
+
+            self.assertEqual(output, 'why not type? 1 5 typing is great! bye False')
 
     def test_double_tapify(self):
         def concat(a: int, b: int, c: int) -> str:
             """Concatenate three numbers."""
             return f'{a} {b} {c}'
 
-        output_1 = tapify(concat, args=['--a', '1', '--b', '2', '--c', '3'])
-        output_2 = tapify(concat, args=['--a', '4', '--b', '5', '--c', '6'])
+        class Concat:
+            """Concatenate three numbers."""
 
-        self.assertEqual(output_1, '1 2 3')
-        self.assertEqual(output_2, '4 5 6')
+            def __init__(self, a: int, b: int, c: int):
+                """Concatenate three numbers."""
+                self.kwargs = {'a': a, 'b': b, 'c': c}
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            """Concatenate three numbers."""
+
+            a: int
+            b: int
+            c: int
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.a, self.b, self.c)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            output_1 = tapify(class_or_function, args=['--a', '1', '--b', '2', '--c', '3'])
+            output_2 = tapify(class_or_function, args=['--a', '4', '--b', '5', '--c', '6'])
+
+            self.assertEqual(output_1, '1 2 3')
+            self.assertEqual(output_2, '4 5 6')
+
+    def test_tapify_args_kwargs(self):
+        def concat(a: int, *args, b: int, **kwargs) -> str:
+            return f'{a} {args} {b} {kwargs}'
+
+        class Concat:
+            def __init__(self, a: int, *args, b: int, **kwargs):
+                self.a = a
+                self.args = args
+                self.b = b
+                self.kwargs = kwargs
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(a=self.a, *self.args, b=self.b, **self.kwargs)
+
+        for class_or_function in [concat, Concat]:
+            with self.assertRaises(SystemExit):
+                tapify(class_or_function, args=['--a', '1', '--b', '2'])
+
+    def test_tapify_help(self):
+        def concat(a: int, b: int, c: int) -> str:
+            """Concatenate three numbers.
+
+            :param a: The first number.
+            :param b: The second number.
+            :param c: The third number.
+            """
+            return f'{a} {b} {c}'
+
+        class Concat:
+            def __init__(self, a: int, b: int, c: int):
+                """Concatenate three numbers.
+
+                :param a: The first number.
+                :param b: The second number.
+                :param c: The third number.
+                """
+                self.kwargs = {'a': a, 'b': b, 'c': c}
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(**self.kwargs)
+
+        @dataclass
+        class ConcatDataclass:
+            """Concatenate three numbers.
+
+            :param a: The first number.
+            :param b: The second number.
+            :param c: The third number.
+            """
+            a: int
+            b: int
+            c: int
+
+            def __eq__(self, other: str) -> bool:
+                return other == concat(self.a, self.b, self.c)
+
+        for class_or_function in [concat, Concat, ConcatDataclass]:
+            f = io.StringIO()
+            with contextlib.redirect_stdout(f):
+                with self.assertRaises(SystemExit):
+                    tapify(class_or_function, args=['-h'])
+
+            self.assertIn('Concatenate three numbers.', f.getvalue())
+            self.assertIn('--a A       (int, required) The first number.', f.getvalue())
+            self.assertIn('--b B       (int, required) The second number.', f.getvalue())
+            self.assertIn('--c C       (int, required) The third number.', f.getvalue())
 
 
 if __name__ == '__main__':

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1,5 +1,7 @@
+import contextlib
+import io
 import sys
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 import unittest
 from unittest import TestCase
 
@@ -184,16 +186,33 @@ class TapifyTests(TestCase):
 
         self.assertEqual(output, 'why not type? 1 5 typing is great! bye False')
 
-# Supported argument types
-# Unsupported types
-# Too many arguments
-# Not enough arguments
-# Some from command line and some from code providing it to the function
-# All arguments from code providing it to the function (just enough, too many, too few)
-# With and without defaults
-# Untyped
+    def test_tapify_help(self):
+        def concat(a: int, b: int, c: int) -> str:
+            """Concatenate three numbers."""
+            return f'{a} {b} {c}'
 
-# Help string
+        sys.stderr = self.dev_null
+        sys.stdout = self.dev_null
+
+        f = io.StringIO()
+        with contextlib.redirect_stdout(f):
+            with self.assertRaises(SystemExit):
+                sys.stderr = self.dev_null
+
+                tapify(concat, args=['-h'])
+
+        self.assertIn('Concatenate three numbers.', f.getvalue())
+
+    def test_double_tapify(self):
+        def concat(a: int, b: int, c: int) -> str:
+            """Concatenate three numbers."""
+            return f'{a} {b} {c}'
+
+        output_1 = tapify(concat, args=['--a', '1', '--b', '2', '--c', '3'])
+        output_2 = tapify(concat, args=['--a', '4', '--b', '5', '--c', '6'])
+
+        self.assertEqual(output_1, '1 2 3')
+        self.assertEqual(output_2, '4 5 6')
 
 
 if __name__ == '__main__':

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1,7 +1,7 @@
 import contextlib
 import io
 import sys
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 import unittest
 from unittest import TestCase
 
@@ -70,7 +70,7 @@ class TapifyTests(TestCase):
         self.assertEqual(output, '1 simple 3.14 -0.3 True wee')
 
     def test_tapify_complex_types(self):
-        def concat(complexity: list[str], requires: tuple[int, int], intelligence: Person) -> str:
+        def concat(complexity: List[str], requires: Tuple[int, int], intelligence: Person) -> str:
             return f'{" ".join(complexity)} {requires[0]} {requires[1]} {intelligence}'
 
         output = tapify(concat, args=[
@@ -81,8 +81,22 @@ class TapifyTests(TestCase):
 
         self.assertEqual(output, 'complex things require 1 0 Person(jesse)')
 
+    @unittest.skipIf(sys.version_info < (3, 9),
+                     'Parameterized standard collections (e.g., list[int]) introduced in Python 3.9')
+    def test_tapify_complex_types_parameterized_standard(self):
+        def concat(complexity: list[int], requires: tuple[int, int], intelligence: Person) -> str:
+            return f'{" ".join(map(str, complexity))} {requires[0]} {requires[1]} {intelligence}'
+
+        output = tapify(concat, args=[
+            '--complexity', '1', '2', '3',
+            '--requires', '1', '0',
+            '--intelligence', 'jesse',
+        ])
+
+        self.assertEqual(output, '1 2 3 1 0 Person(jesse)')
+
     def test_tapify_complex_types_defaults(self):
-        def concat(complexity: list[str],
+        def concat(complexity: List[str],
                    requires: Tuple[int, int] = (2, 5),
                    intelligence: Person = Person('kyle'),
                    maybe: Optional[str] = None,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -495,7 +495,7 @@ class PythonObjectEncoderTests(TestCase):
         obj = [1, CannotPickleThis()]
         expected_obj = [1, UnpicklableObject()]
         with self.assertRaises(ValueError):
-            dumps = json.dumps(obj, indent=4, sort_keys=True, cls=define_python_object_encoder())
+            json.dumps(obj, indent=4, sort_keys=True, cls=define_python_object_encoder())
 
         dumps = json.dumps(obj, indent=4, sort_keys=True, cls=define_python_object_encoder(True))
         recreated_obj = json.loads(dumps, object_hook=as_python_object)


### PR DESCRIPTION
`tapify` makes it possible to run functions via command line arguments. This is similar to Google's [Python Fire](https://github.com/google/python-fire), but `tapify` also automatically casts command line arguments to the appropriate types based on the function's type hints. Under the hood, `tapify` implicitly creates a `Tap` object and uses it to parse the command line arguments, which it then uses to run the function. Below is an example.

```python
# code.py
from tap import tapify

def add(num_1: float, num_2: float) -> float:
    print(f'The sum of {num_1} and {num_2} is {num_1 + num_2}.')

if __name__ == '__main__':
    tapify(add)
```

Running `python code.py --num_1 5 --num_2 10` prints `The sum of 5 and 10 is 15.`

This PR also makes fixes to support Python 3.11.