### PR TITLE
support for ignoring args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .eggs
 .coverage
 dist
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .eggs
 .coverage
 dist
+build

--- a/tap/__init__.py
+++ b/tap/__init__.py
@@ -2,5 +2,6 @@ from argparse import ArgumentError, ArgumentTypeError
 from tap._version import __version__
 from tap.tap import Tap
 from tap.tapify import tapify
+from tap.utils import TapIgnore
 
-__all__ = ['ArgumentError', 'ArgumentTypeError', 'Tap', 'tapify', '__version__']
+__all__ = ['ArgumentError', 'ArgumentTypeError', 'Tap', 'TapIgnore', 'tapify', '__version__']

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -23,10 +23,10 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    _SpecialForm,
+    TypeVar,
+    Generic,
 )
 from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
-from typing_inspect import _GenericAlias
 
 if sys.version_info >= (3, 10):
     from types import UnionType
@@ -34,6 +34,9 @@ if sys.version_info >= (3, 10):
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
 PRIMITIVES = (str, int, float, bool)
 PathLike = Union[str, os.PathLike]
+T = TypeVar('T')
+class TapIgnore(Generic[T]):
+    ...
 
 
 def check_output(command: List[str], suppress_stderr: bool = True, **kwargs) -> str:
@@ -131,7 +134,7 @@ def type_to_str(type_annotation: Union[type, Any]) -> str:
         return type_annotation.__name__
 
     # Typing type
-    return str(type_annotation).replace('typing.', '')
+    return str(type_annotation).replace('typing.', '').replace("tap.utils.", "")
 
 
 def get_argument_name(*name_or_flags) -> str:
@@ -516,9 +519,3 @@ def get_args(tp: Any) -> Tuple[type, ...]:
         return tp.__args__
 
     return typing_inspect_get_args(tp)
-
-@_SpecialForm
-def TapIgnore(self, parameters):
-    if not callable(parameters):
-        raise TypeError(f"{self} only accepts single type, got {parameters!r:.100}.")
-    return _GenericAlias(self, (parameters,))

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -23,8 +23,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    TypeVar,
-    Generic,
+    ClassVar,
 )
 from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
 
@@ -34,10 +33,10 @@ if sys.version_info >= (3, 10):
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
 PRIMITIVES = (str, int, float, bool)
 PathLike = Union[str, os.PathLike]
-T = TypeVar('T')
-class TapIgnore(Generic[T]):
-    ...
 
+# use some hacks to implement the hint in IDE, like ClassVar
+TapIgnore = ClassVar
+TapIgnore._name = "TapIgnore"
 
 def check_output(command: List[str], suppress_stderr: bool = True, **kwargs) -> str:
     """Runs subprocess.check_output and returns the result as a string.
@@ -134,7 +133,7 @@ def type_to_str(type_annotation: Union[type, Any]) -> str:
         return type_annotation.__name__
 
     # Typing type
-    return str(type_annotation).replace('typing.', '').replace("tap.utils.", "")
+    return str(type_annotation).replace('typing.', '')
 
 
 def get_argument_name(*name_or_flags) -> str:

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -23,7 +23,6 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    ClassVar,
 )
 from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
 
@@ -35,8 +34,16 @@ PRIMITIVES = (str, int, float, bool)
 PathLike = Union[str, os.PathLike]
 
 # use some hacks to implement the hint in IDE, like ClassVar
-TapIgnore = ClassVar
-TapIgnore._name = "TapIgnore"
+if sys.version_info >= (3, 9):
+    from typing import ClassVar
+    TapIgnore = ClassVar
+    TapIgnore._name = "TapIgnore"
+else:
+    # for python version <= 3.8, the above method not supported,
+    # so for now,  TapIgnore[T] -> T not supported
+    from typing import TypeVar, Generic
+    T = TypeVar("T")
+    class TapIgnore(Generic[T]): ...
 
 def check_output(command: List[str], suppress_stderr: bool = True, **kwargs) -> str:
     """Runs subprocess.check_output and returns the result as a string.
@@ -133,7 +140,7 @@ def type_to_str(type_annotation: Union[type, Any]) -> str:
         return type_annotation.__name__
 
     # Typing type
-    return str(type_annotation).replace('typing.', '')
+    return str(type_annotation).replace('typing.', '').replace('tap.utils.', '')
 
 
 def get_argument_name(*name_or_flags) -> str:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,11 +5,11 @@ from pathlib import Path
 import pickle
 import sys
 from tempfile import TemporaryDirectory
-from typing import Any, Iterable, List, Literal, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Tuple, Union
 import unittest
 from unittest import TestCase
 
-from tap import Tap
+from tap import Tap, TapIgnore
 
 
 # Suppress prints from SystemExit
@@ -330,6 +330,14 @@ class IntegrationDefaultTap(Tap):
     # TODO: move these elsewhere since we don't support them as defaults
     # arg_other_type_required: Person
     # arg_other_type_default: Person = Person('tap')
+    arg_ignore: str  # tap: ignore
+    arg_tapignore: TapIgnore
+    arg_tapignore_int: TapIgnore[int]
+    arg_tapignore_bool: TapIgnore[bool]
+    arg_tapignore_str: TapIgnore[str]
+    arg_tapignore_union: TapIgnore[Union[int, str]]
+    arg_tapignore_dict: TapIgnore[Dict[int, int]]
+    arg_tapignore_customed: TapIgnore[Person]
 
 
 class SubclassTests(TestCase):
@@ -402,6 +410,17 @@ class DefaultClassVariableTests(TestCase):
         self.assertEqual(args.arg_tuple_float, (3.14, 6.28))
         self.assertEqual(args.arg_tuple_bool, (True, True, True, False))
         self.assertEqual(args.arg_tuple_multi, (1.2, 1, 'hi', True, 1.3))
+
+        # test for ignored args
+        self.assertFalse(hasattr(args, 'arg_ignore'))
+        self.assertFalse(hasattr(args, 'arg_tapignore'))
+        self.assertFalse(hasattr(args, 'arg_tapignore_int'))
+        self.assertFalse(hasattr(args, 'arg_tapignore_bool'))
+        self.assertFalse(hasattr(args, 'arg_tapignore_str'))
+        self.assertFalse(hasattr(args, 'arg_tapignore_union'))
+        self.assertFalse(hasattr(args, 'arg_tapignore_dict'))
+        self.assertFalse(hasattr(args, 'arg_tapignore_customed'))
+
 
     def test_set_default_args(self) -> None:
         arg_untyped = 'yes'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from tap.utils import (
     UnpicklableObject,
     as_python_object,
     enforce_reproducibility,
+    TapIgnore,
 )
 
 
@@ -134,6 +135,8 @@ class TypeToStrTests(TestCase):
         self.assertEqual(type_to_str(Set[int]), 'Set[int]')
         self.assertEqual(type_to_str(Dict[str, int]), 'Dict[str, int]')
         self.assertEqual(type_to_str(Union[List[int], Dict[float, bool]]), 'Union[List[int], Dict[float, bool]]')
+        self.assertEqual(type_to_str(TapIgnore), "TapIgnore")
+        self.assertEqual(type_to_str(TapIgnore[int]), "TapIgnore[int]")
 
 
 def class_decorator(cls):


### PR DESCRIPTION
Just do the same thing as #75 and #92 , but meet the format mentioned at https://github.com/swansonk14/typed-argument-parser/pull/92#issuecomment-1435766167

for now, args can be ignored as follow:

```python
# test.py

from tap import Tap, TapIgnore

class MyTapWithIgnore(Tap):
    arg_to_ignore_by_comment: str  # tap: ignore
    attr_to_ignore: TapIgnore[str]
    classvar_attr: TapIgnore[str]
    hello: str = "hello"

args = MyTapWithIgnore().parse_args()

print(args)
```
and the output:
```console
python test.py -h
usage: test.py [--hello HELLO] [-h]

options:
  --hello HELLO  (str, default=hello)
  -h, --help     show this help message and exit
```

```console
python test.py
{'hello': 'hello'}
```

By the way, some codes were borrowed from #92 and the official typing library.