### PR TITLE
Fixed bug with incorrect type annotation of class instance created by tapify

### DIFF
--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -1,6 +1,6 @@
 """Tapify module, which can initialize a class or run a function by parsing arguments from the command line."""
 from inspect import signature, Parameter
-from typing import Any, Callable, List, Optional, TypeVar, Union
+from typing import Any, Callable, List, Optional, Type, TypeVar, Union
 
 from docstring_parser import parse
 
@@ -10,7 +10,7 @@ InputType = TypeVar('InputType')
 OutputType = TypeVar('OutputType')
 
 
-def tapify(class_or_function: Union[Callable[[InputType], OutputType], OutputType],
+def tapify(class_or_function: Union[Callable[[InputType], OutputType], Type[OutputType]],
            known_only: bool = False,
            command_line_args: Optional[List[str]] = None,
            **func_kwargs) -> OutputType:


### PR DESCRIPTION
When class is set to tapify, the created instance is returned as `type[class]`, not type `class`.

For example, if I create an `ABC` class and input it to the `tapify` function, the return type is `type[ABC]`, not `ABC`.
<img width="238" alt="image" src="https://github.com/swansonk14/typed-argument-parser/assets/38306927/9183d9c2-48b9-463e-9d2e-c87aec092c68">


So change input type of tapify from `Union[Callable[[InputType], OutputType], OutputType]`  to `Union[Callable[[InputType], OutputType], Type[OutputType]]`
<img width="203" alt="image" src="https://github.com/swansonk14/typed-argument-parser/assets/38306927/b73fc67b-3fac-478a-896e-ec82a12aa25b">
