### PR TITLE
Declare support for (and test with) Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@main

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         "Typing :: Typed"


### PR DESCRIPTION
Hi! This PR adds Python 3.12 to the `tests.yml` workflow, and declares in `setup.py` that the project supports Python 3.12.

All of the project's tests pass on Python 3.12 -- there are a few new DeprecationWarnings from some of the project's dependencies, but nothing that `tap` needs to worry about, I don't think.