### PR TITLE
Fix #134: compare Pydantic version string correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,11 @@ setup(
     license="MIT",
     packages=find_packages(),
     package_data={"tap": ["py.typed"]},
-    install_requires=["typing-inspect >= 0.7.1", "docstring-parser >= 0.15"],
+    install_requires=[
+        "docstring-parser >= 0.15",
+        "packaging",
+        "typing-inspect >= 0.7.1",
+    ],
     tests_require=test_requirements,
     extras_require={
         "dev-no-pydantic": test_requirements,

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -10,6 +10,7 @@ import inspect
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, TypeVar, Union
 
 from docstring_parser import Docstring, parse
+from packaging.version import Version
 
 try:
     import pydantic
@@ -20,7 +21,7 @@ except ModuleNotFoundError:
     _PydanticField = type("_PydanticField", (object,), {})
     _PYDANTIC_FIELD_TYPES = ()
 else:
-    _IS_PYDANTIC_V1 = pydantic.__version__ < "2.0.0"
+    _IS_PYDANTIC_V1 = Version(pydantic.__version__) < Version("2.0.0")
     from pydantic import BaseModel
     from pydantic.fields import FieldInfo as PydanticFieldBaseModel
     from pydantic.dataclasses import FieldInfo as PydanticFieldDataclass

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Optional, Tuple, Any
 import unittest
 from unittest import TestCase
 
+from packaging.version import Version
+
 from tap import tapify
 
 
@@ -18,7 +20,7 @@ try:
 except ModuleNotFoundError:
     _IS_PYDANTIC_V1 = None
 else:
-    _IS_PYDANTIC_V1 = pydantic.__version__ < "2.0.0"
+    _IS_PYDANTIC_V1 = Version(pydantic.__version__) < Version("2.0.0")
 
 
 # Suppress prints from SystemExit

--- a/tests/test_to_tap_class.py
+++ b/tests/test_to_tap_class.py
@@ -9,6 +9,7 @@ import re
 import sys
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
+from packaging.version import Version
 import pytest
 
 from tap import to_tap_class, Tap
@@ -20,7 +21,7 @@ try:
 except ModuleNotFoundError:
     _IS_PYDANTIC_V1 = None
 else:
-    _IS_PYDANTIC_V1 = pydantic.__version__ < "2.0.0"
+    _IS_PYDANTIC_V1 = Version(pydantic.__version__) < Version("2.0.0")
 
 
 # To properly test the help message, we need to know how argparse formats it. It changed from 3.8 -> 3.9 -> 3.10


### PR DESCRIPTION
Fix #134.

Adds a new dependency: [`packaging`](https://packaging.pypa.io/en/stable/). It has no dependencies and works w/ Python 3.8+.

See docs for [`packaging.version.Version`](https://packaging.pypa.io/en/latest/version.html#packaging.version.Version)
