### PR TITLE
Clean the code, type annotations and update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "docstring-parser >= 0.15",
         "packaging",
-        "typing-inspect >= 0.7.1",
+        "typing-inspect >= 0.9.0",
     ],
     tests_require=test_requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     install_requires=[
         "docstring-parser >= 0.15",
         "packaging",
-        "typing-inspect >= 0.9.0",
     ],
     tests_require=test_requirements,
     extras_require={

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -323,10 +323,9 @@ class Tap(ArgumentParser):
 
     def process_args(self) -> None:
         """Perform additional argument processing and/or validation."""
-        pass
 
     def add_subparser(self, flag: str, subparser_type: type, **kwargs) -> None:
-        """Add a subparser to the collection of subparsers"""
+        """Add a subparser to the collection of subparsers."""
         help_desc = kwargs.get("help", subparser_type.__doc__)
         kwargs["help"] = help_desc
 
@@ -369,7 +368,6 @@ class Tap(ArgumentParser):
             self.add_subparsers(help='sub-command help')
             self.add_subparser('a', SubparserA, help='a help')
         """
-        pass
 
     @staticmethod
     def get_reproducibility_info(repo_path: PathLike | None = None) -> dict[str, str]:
@@ -531,9 +529,7 @@ class Tap(ArgumentParser):
             if not (
                 var.startswith("_")
                 or callable(val)
-                or isinstance(val, staticmethod)
-                or isinstance(val, classmethod)
-                or isinstance(val, property)
+                or isinstance(val, (staticmethod, classmethod, property))
             )
         }
 
@@ -598,7 +594,7 @@ class Tap(ArgumentParser):
         stored_dict = {
             var: getattr(self, var)
             for var, val in stored_dict.items()
-            if not (var.startswith("_") or isinstance(val, MethodType) or isinstance(val, staticmethod))
+            if not (var.startswith("_") or isinstance(val, (MethodType, staticmethod)))
         }
 
         tap_class_dict_keys = Tap().__dict__.keys() | Tap.__dict__.keys()
@@ -626,16 +622,16 @@ class Tap(ArgumentParser):
             )
 
         # Load all arguments
-        for key, value in args_dict.items():
-            try:
+        try:
+            for key, value in args_dict.items():
                 setattr(self, key, value)
-            except AttributeError:
-                if not skip_unsettable:
-                    raise AttributeError(
+        except AttributeError as e:
+            if not skip_unsettable:
+                raise AttributeError(
                         f'Cannot set attribute "{key}" to "{value}". '
                         f"To skip arguments that cannot be set \n"
                         f'\t"skip_unsettable = True"'
-                    )
+                    ) from e
 
         self._parsed = True
 
@@ -706,8 +702,8 @@ class Tap(ArgumentParser):
         if config_files is not None:
             # Read arguments from all configs from the lowest precedence config to the highest
             for file in config_files:
-                with open(file) as f:
-                    args_from_config.append(f.read().strip())
+                text = Path(file).read_text(encoding="utf-8").strip()
+                args_from_config.append(text)
 
         return args_from_config
 

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -26,7 +26,6 @@ from tap.utils import (
     TupleTypeEnforcer,
     define_python_object_encoder,
     as_python_object,
-    fix_py36_copy,
     enforce_reproducibility,
     PathLike,
     ReproducibilityInfo
@@ -713,7 +712,6 @@ class Tap(ArgumentParser):
         """
         return pformat(self.as_dict())
 
-    @fix_py36_copy
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> TapType:
         """Deepcopy the Tap object."""
         copied = type(self).__new__(type(self))

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import sys
 import time
@@ -10,7 +8,7 @@ from pathlib import Path
 from pprint import pformat
 from shlex import quote, split
 from types import MethodType
-from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
+from typing import Any, Callable, List, Dict, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
 from typing_inspect import is_literal_type, get_origin, get_args
 
 from tap.utils import (
@@ -54,7 +52,7 @@ class Tap(ArgumentParser):
         *args,
         underscores_to_dashes: bool = False,
         explicit_bool: bool = False,
-        config_files: list[PathLike] | None = None,
+        config_files: Optional[List[PathLike]] = None,
         **kwargs,
     ):
         """Initializes the Tap instance.
@@ -89,7 +87,7 @@ class Tap(ArgumentParser):
         self.argument_buffer = {}
 
         # Create a place to put the subparsers
-        self._subparser_buffer: list[tuple[str, type, dict[str, Any]]] = []
+        self._subparser_buffer: List[Tuple[str, type, Dict[str, Any]]] = []
 
         # Get class variables help strings from the comments
         self.class_variables = self._get_class_variables()
@@ -330,7 +328,7 @@ class Tap(ArgumentParser):
         self._subparser_buffer.append((flag, subparser_type, kwargs))
 
     def _add_subparsers(self) -> None:
-        """Add each of the subparsers to the Tap object."""
+        """Add each of the subparsers to the Tap object. """
         # Initialize the _subparsers object if not already created
         if self._subparsers is None and len(self._subparser_buffer) > 0:
             self._subparsers = super(Tap, self).add_subparsers()
@@ -344,7 +342,7 @@ class Tap(ArgumentParser):
         self._subparsers = super().add_subparsers(**kwargs)
 
     def _configure(self) -> None:
-        """Executes the user-defined configuration."""
+        """Executes the user-defined configuration. """
         # Call the user-defined configuration
         self.configure()
 
@@ -368,7 +366,7 @@ class Tap(ArgumentParser):
         """
 
     @staticmethod
-    def get_reproducibility_info(repo_path: PathLike | None = None) -> ReproducibilityInfo:
+    def get_reproducibility_info(repo_path: Optional[PathLike] = None) -> dict[str, str]:
         """Gets a dictionary of reproducibility information.
 
         Reproducibility information always includes:
@@ -403,7 +401,7 @@ class Tap(ArgumentParser):
 
         return reproducibility
 
-    def _log_all(self, repo_path: PathLike | None = None) -> dict[str, Any]:
+    def _log_all(self, repo_path: Optional[PathLike] = None) -> Dict[str, Any]:
         """Gets all arguments along with reproducibility information.
 
         :param repo_path: Path to the git repo to examine for reproducibility info.
@@ -416,7 +414,7 @@ class Tap(ArgumentParser):
         return arg_log
 
     def parse_args(
-        self: TapType, args: Sequence[str] | None = None, known_only: bool = False, legacy_config_parsing=False
+        self: TapType, args: Optional[Sequence[str]] = None, known_only: bool = False, legacy_config_parsing=False
     ) -> TapType:
         """Parses arguments, sets attributes of self equal to the parsed arguments, and processes arguments.
 
@@ -481,7 +479,7 @@ class Tap(ArgumentParser):
         return self
 
     @classmethod
-    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> dict[str, Any] | dict:
+    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> Union[Dict[str, Any], Dict]:
         """Returns a dictionary mapping variable names to values.
 
         Variables and values are extracted from classes using key starting
@@ -516,7 +514,7 @@ class Tap(ArgumentParser):
 
         return dictionary
 
-    def _get_class_dict(self) -> dict[str, Any]:
+    def _get_class_dict(self) -> Dict[str, Any]:
         """Returns a dictionary mapping class variable names to values from the class dict."""
         class_dict = self._get_from_self_and_super(
             extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict()))
@@ -533,7 +531,7 @@ class Tap(ArgumentParser):
 
         return class_dict
 
-    def _get_annotations(self) -> dict[str, Any]:
+    def _get_annotations(self) -> Dict[str, Any]:
         """Returns a dictionary mapping variable names to their type annotations."""
         return self._get_from_self_and_super(extract_func=lambda super_class: dict(get_type_hints(super_class)))
 
@@ -563,7 +561,7 @@ class Tap(ArgumentParser):
 
         return class_variables
 
-    def _get_argument_names(self) -> set[str]:
+    def _get_argument_names(self) -> Set[str]:
         """Returns a list of variable names corresponding to the arguments."""
         return (
             {get_dest(*name_or_flags, **kwargs) for name_or_flags, kwargs in self.argument_buffer.values()}
@@ -571,7 +569,7 @@ class Tap(ArgumentParser):
             | set(self._annotations.keys())
         ) - {"help"}
 
-    def as_dict(self) -> dict[str, Any]:
+    def as_dict(self) -> Dict[str, Any]:
         """Returns the member variables corresponding to the parsed arguments.
 
         Note: This does not include attributes set directly on an instance
@@ -600,7 +598,7 @@ class Tap(ArgumentParser):
 
         return stored_dict
 
-    def from_dict(self, args_dict: dict[str, Any], skip_unsettable: bool = False) -> TapType:
+    def from_dict(self, args_dict: Dict[str, Any], skip_unsettable: bool = False) -> TapType:
         """Loads arguments from a dictionary, ensuring all required arguments are set.
 
         :param args_dict: A dictionary from argument names to the values of the arguments.
@@ -640,7 +638,7 @@ class Tap(ArgumentParser):
         path: PathLike,
         with_reproducibility: bool = True,
         skip_unpicklable: bool = False,
-        repo_path: PathLike | None = None,
+        repo_path: Optional[PathLike] = None,
     ) -> None:
         """Saves the arguments and reproducibility information in JSON format, pickling what can't be encoded.
 
@@ -660,7 +658,7 @@ class Tap(ArgumentParser):
         path: PathLike,
         check_reproducibility: bool = False,
         skip_unsettable: bool = False,
-        repo_path: PathLike | None = None,
+        repo_path: Optional[PathLike] = None,
     ) -> TapType:
         """Loads the arguments in JSON format. Note: Due to JSON, tuples are loaded as lists.
 
@@ -686,7 +684,7 @@ class Tap(ArgumentParser):
 
         return self
 
-    def _load_from_config_files(self, config_files: list[PathLike] | None) -> list[str]:
+    def _load_from_config_files(self, config_files: Optional[list[PathLike]]) -> list[str]:
         """Loads arguments from a list of configuration files containing command line arguments.
 
         :param config_files: A list of paths to configuration files containing the command line arguments
@@ -712,7 +710,8 @@ class Tap(ArgumentParser):
         """
         return pformat(self.as_dict())
 
-    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> TapType:
+    @fix_py36_copy
+    def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> TapType:
         """Deepcopy the Tap object."""
         copied = type(self).__new__(type(self))
 
@@ -721,16 +720,16 @@ class Tap(ArgumentParser):
 
         memo[id(self)] = copied
 
-        for k, v in self.__dict__.items():
+        for (k, v) in self.__dict__.items():
             copied.__dict__[k] = deepcopy(v, memo)
 
         return copied
 
-    def __getstate__(self) -> dict[str, Any]:
+    def __getstate__(self) -> Dict[str, Any]:
         """Gets the state of the object for pickling."""
         return self.as_dict()
 
-    def __setstate__(self, d: dict[str, Any]) -> None:
+    def __setstate__(self, d: Dict[str, Any]) -> None:
         """
         Initializes the object with the provided dictionary of arguments for unpickling.
 

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -719,7 +719,7 @@ class Tap(ArgumentParser):
         return pformat(self.as_dict())
 
     @fix_py36_copy
-    def __deepcopy__(self, memo: dict[int, Any] = None) -> TapType:
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> TapType:
         """Deepcopy the Tap object."""
         copied = type(self).__new__(type(self))
 

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -29,6 +29,7 @@ from tap.utils import (
     fix_py36_copy,
     enforce_reproducibility,
     PathLike,
+    ReproducibilityInfo
 )
 
 if sys.version_info >= (3, 10):
@@ -368,7 +369,7 @@ class Tap(ArgumentParser):
         """
 
     @staticmethod
-    def get_reproducibility_info(repo_path: PathLike | None = None) -> dict[str, str]:
+    def get_reproducibility_info(repo_path: PathLike | None = None) -> ReproducibilityInfo:
         """Gets a dictionary of reproducibility information.
 
         Reproducibility information always includes:
@@ -686,7 +687,7 @@ class Tap(ArgumentParser):
 
         return self
 
-    def _load_from_config_files(self, config_files: list[str] | None) -> list[str]:
+    def _load_from_config_files(self, config_files: list[PathLike] | None) -> list[str]:
         """Loads arguments from a list of configuration files containing command line arguments.
 
         :param config_files: A list of paths to configuration files containing the command line arguments

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -20,8 +20,6 @@ from typing import (
     TypeVar,
     Union,
     get_type_hints,
-    get_args,
-    get_origin,
 )
 
 from tap.utils import (
@@ -33,14 +31,16 @@ from tap.utils import (
     is_positional_arg,
     type_to_str,
     get_literals,
+    is_literal_type,
     boolean_type,
     TupleTypeEnforcer,
     define_python_object_encoder,
     as_python_object,
     enforce_reproducibility,
     PathLike,
+    get_args,
+    get_origin,
 )
-
 if sys.version_info >= (3, 10):
     from types import UnionType
 
@@ -630,16 +630,16 @@ class Tap(ArgumentParser):
             )
 
         # Load all arguments
-        try:
-            for key, value in args_dict.items():
+        for key, value in args_dict.items():
+            try:
                 setattr(self, key, value)
-        except AttributeError as e:
-            if not skip_unsettable:
-                raise AttributeError(
-                        f'Cannot set attribute "{key}" to "{value}". '
-                        f"To skip arguments that cannot be set \n"
-                        f'\t"skip_unsettable = True"'
-                    ) from e
+            except AttributeError as e:
+                if not skip_unsettable:
+                    raise AttributeError(
+                            f'Cannot set attribute "{key}" to "{value}". '
+                            f"To skip arguments that cannot be set \n"
+                            f'\t"skip_unsettable = True"'
+                        ) from e
 
         self._parsed = True
 
@@ -722,7 +722,6 @@ class Tap(ArgumentParser):
         """
         return pformat(self.as_dict())
 
-    @fix_py36_copy
     def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> TapType:
         """Deepcopy the Tap object."""
         copied = type(self).__new__(type(self))

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -188,7 +188,7 @@ class Tap(ArgumentParser):
                         var_args = (str, type(None))
 
                     # Raise error if type function is not explicitly provided for Union types (not including Optionals)
-                    if get_origin(var_type) in UNION_TYPES and not (len(var_args) == 2 and var_args[1] == type(None)):
+                    if get_origin(var_type) in UNION_TYPES and not (len(var_args) == 2 and var_args[1] is type(None)):
                         raise ArgumentTypeError(
                             "For Union types, you must include an explicit type function in the configure method. "
                             "For example,\n\n"
@@ -265,11 +265,11 @@ class Tap(ArgumentParser):
                         var_type = arg_types[0]
 
                     # Handle the cases of List[bool], Set[bool], Tuple[bool]
-                    if var_type == bool:
+                    if var_type is bool:
                         var_type = boolean_type
 
                 # If bool then set action, otherwise set type
-                if var_type == bool:
+                if var_type is bool:
                     if explicit_bool:
                         kwargs["type"] = boolean_type
                         kwargs["choices"] = [True, False]  # this makes the help message more helpful
@@ -454,7 +454,7 @@ class Tap(ArgumentParser):
         for variable, value in vars(default_namespace).items():
             # Conversion from list to set or tuple
             if variable in self._annotations:
-                if type(value) == list:
+                if type(value) is list:
                     var_type = get_origin(self._annotations[variable])
 
                     # Unpack nested boxed types such as Optional[List[int]]

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -11,14 +11,12 @@ from pprint import pformat
 from shlex import quote, split
 from types import MethodType
 from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
-from typing_inspect import is_literal_type
+from typing_inspect import is_literal_type, get_origin, get_args
 
 from tap.utils import (
     get_class_variables,
-    get_args,
     get_argument_name,
     get_dest,
-    get_origin,
     GitInfo,
     is_option_arg,
     is_positional_arg,

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import sys
 import time
@@ -8,7 +10,7 @@ from pathlib import Path
 from pprint import pformat
 from shlex import quote, split
 from types import MethodType
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
+from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
 from typing_inspect import is_literal_type
 
 from tap.utils import (
@@ -54,7 +56,7 @@ class Tap(ArgumentParser):
         *args,
         underscores_to_dashes: bool = False,
         explicit_bool: bool = False,
-        config_files: Optional[List[PathLike]] = None,
+        config_files: list[PathLike] | None = None,
         **kwargs,
     ):
         """Initializes the Tap instance.
@@ -89,7 +91,7 @@ class Tap(ArgumentParser):
         self.argument_buffer = {}
 
         # Create a place to put the subparsers
-        self._subparser_buffer: List[Tuple[str, type, Dict[str, Any]]] = []
+        self._subparser_buffer: list[tuple[str, type, dict[str, Any]]] = []
 
         # Get class variables help strings from the comments
         self.class_variables = self._get_class_variables()
@@ -331,7 +333,7 @@ class Tap(ArgumentParser):
         self._subparser_buffer.append((flag, subparser_type, kwargs))
 
     def _add_subparsers(self) -> None:
-        """Add each of the subparsers to the Tap object. """
+        """Add each of the subparsers to the Tap object."""
         # Initialize the _subparsers object if not already created
         if self._subparsers is None and len(self._subparser_buffer) > 0:
             self._subparsers = super(Tap, self).add_subparsers()
@@ -345,7 +347,7 @@ class Tap(ArgumentParser):
         self._subparsers = super().add_subparsers(**kwargs)
 
     def _configure(self) -> None:
-        """Executes the user-defined configuration. """
+        """Executes the user-defined configuration."""
         # Call the user-defined configuration
         self.configure()
 
@@ -370,7 +372,7 @@ class Tap(ArgumentParser):
         pass
 
     @staticmethod
-    def get_reproducibility_info(repo_path: Optional[PathLike] = None) -> Dict[str, str]:
+    def get_reproducibility_info(repo_path: PathLike | None = None) -> dict[str, str]:
         """Gets a dictionary of reproducibility information.
 
         Reproducibility information always includes:
@@ -405,7 +407,7 @@ class Tap(ArgumentParser):
 
         return reproducibility
 
-    def _log_all(self, repo_path: Optional[PathLike] = None) -> Dict[str, Any]:
+    def _log_all(self, repo_path: PathLike | None = None) -> dict[str, Any]:
         """Gets all arguments along with reproducibility information.
 
         :param repo_path: Path to the git repo to examine for reproducibility info.
@@ -418,7 +420,7 @@ class Tap(ArgumentParser):
         return arg_log
 
     def parse_args(
-        self: TapType, args: Optional[Sequence[str]] = None, known_only: bool = False, legacy_config_parsing=False
+        self: TapType, args: Sequence[str] | None = None, known_only: bool = False, legacy_config_parsing=False
     ) -> TapType:
         """Parses arguments, sets attributes of self equal to the parsed arguments, and processes arguments.
 
@@ -483,7 +485,7 @@ class Tap(ArgumentParser):
         return self
 
     @classmethod
-    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> Union[Dict[str, Any], Dict]:
+    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> dict[str, Any] | dict:
         """Returns a dictionary mapping variable names to values.
 
         Variables and values are extracted from classes using key starting
@@ -518,7 +520,7 @@ class Tap(ArgumentParser):
 
         return dictionary
 
-    def _get_class_dict(self) -> Dict[str, Any]:
+    def _get_class_dict(self) -> dict[str, Any]:
         """Returns a dictionary mapping class variable names to values from the class dict."""
         class_dict = self._get_from_self_and_super(
             extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict()))
@@ -537,7 +539,7 @@ class Tap(ArgumentParser):
 
         return class_dict
 
-    def _get_annotations(self) -> Dict[str, Any]:
+    def _get_annotations(self) -> dict[str, Any]:
         """Returns a dictionary mapping variable names to their type annotations."""
         return self._get_from_self_and_super(extract_func=lambda super_class: dict(get_type_hints(super_class)))
 
@@ -567,7 +569,7 @@ class Tap(ArgumentParser):
 
         return class_variables
 
-    def _get_argument_names(self) -> Set[str]:
+    def _get_argument_names(self) -> set[str]:
         """Returns a list of variable names corresponding to the arguments."""
         return (
             {get_dest(*name_or_flags, **kwargs) for name_or_flags, kwargs in self.argument_buffer.values()}
@@ -575,7 +577,7 @@ class Tap(ArgumentParser):
             | set(self._annotations.keys())
         ) - {"help"}
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> dict[str, Any]:
         """Returns the member variables corresponding to the parsed arguments.
 
         Note: This does not include attributes set directly on an instance
@@ -604,7 +606,7 @@ class Tap(ArgumentParser):
 
         return stored_dict
 
-    def from_dict(self, args_dict: Dict[str, Any], skip_unsettable: bool = False) -> TapType:
+    def from_dict(self, args_dict: dict[str, Any], skip_unsettable: bool = False) -> TapType:
         """Loads arguments from a dictionary, ensuring all required arguments are set.
 
         :param args_dict: A dictionary from argument names to the values of the arguments.
@@ -644,7 +646,7 @@ class Tap(ArgumentParser):
         path: PathLike,
         with_reproducibility: bool = True,
         skip_unpicklable: bool = False,
-        repo_path: Optional[PathLike] = None,
+        repo_path: PathLike | None = None,
     ) -> None:
         """Saves the arguments and reproducibility information in JSON format, pickling what can't be encoded.
 
@@ -664,7 +666,7 @@ class Tap(ArgumentParser):
         path: PathLike,
         check_reproducibility: bool = False,
         skip_unsettable: bool = False,
-        repo_path: Optional[PathLike] = None,
+        repo_path: PathLike | None = None,
     ) -> TapType:
         """Loads the arguments in JSON format. Note: Due to JSON, tuples are loaded as lists.
 
@@ -690,7 +692,7 @@ class Tap(ArgumentParser):
 
         return self
 
-    def _load_from_config_files(self, config_files: Optional[List[str]]) -> List[str]:
+    def _load_from_config_files(self, config_files: list[str] | None) -> list[str]:
         """Loads arguments from a list of configuration files containing command line arguments.
 
         :param config_files: A list of paths to configuration files containing the command line arguments
@@ -717,7 +719,7 @@ class Tap(ArgumentParser):
         return pformat(self.as_dict())
 
     @fix_py36_copy
-    def __deepcopy__(self, memo: Dict[int, Any] = None) -> TapType:
+    def __deepcopy__(self, memo: dict[int, Any] = None) -> TapType:
         """Deepcopy the Tap object."""
         copied = type(self).__new__(type(self))
 
@@ -726,16 +728,16 @@ class Tap(ArgumentParser):
 
         memo[id(self)] = copied
 
-        for (k, v) in self.__dict__.items():
+        for k, v in self.__dict__.items():
             copied.__dict__[k] = deepcopy(v, memo)
 
         return copied
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> dict[str, Any]:
         """Gets the state of the object for pickling."""
         return self.as_dict()
 
-    def __setstate__(self, d: Dict[str, Any]) -> None:
+    def __setstate__(self, d: dict[str, Any]) -> None:
         """
         Initializes the object with the provided dictionary of arguments for unpickling.
 

--- a/tap/tap.py
+++ b/tap/tap.py
@@ -8,8 +8,21 @@ from pathlib import Path
 from pprint import pformat
 from shlex import quote, split
 from types import MethodType
-from typing import Any, Callable, List, Dict, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
-from typing_inspect import is_literal_type, get_origin, get_args
+from typing import (
+    Any,
+    Callable,
+    List,
+    Dict,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+    get_type_hints,
+    get_args,
+    get_origin,
+)
 
 from tap.utils import (
     get_class_variables,
@@ -26,7 +39,6 @@ from tap.utils import (
     as_python_object,
     enforce_reproducibility,
     PathLike,
-    ReproducibilityInfo
 )
 
 if sys.version_info >= (3, 10):
@@ -366,7 +378,7 @@ class Tap(ArgumentParser):
         """
 
     @staticmethod
-    def get_reproducibility_info(repo_path: Optional[PathLike] = None) -> dict[str, str]:
+    def get_reproducibility_info(repo_path: Optional[PathLike] = None) -> Dict[str, str]:
         """Gets a dictionary of reproducibility information.
 
         Reproducibility information always includes:
@@ -684,7 +696,7 @@ class Tap(ArgumentParser):
 
         return self
 
-    def _load_from_config_files(self, config_files: Optional[list[PathLike]]) -> list[str]:
+    def _load_from_config_files(self, config_files: Optional[List[PathLike]]) -> List[str]:
         """Loads arguments from a list of configuration files containing command line arguments.
 
         :param config_files: A list of paths to configuration files containing the command line arguments

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -4,10 +4,11 @@
 `to_tap_class`: convert a class or function into a `Tap` class, which can then be subclassed to add special argument
 handling
 """
+from __future__ import annotations
 
 import dataclasses
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Sequence, Type, TypeVar, Union
+from typing import Any, Callable, Sequence, Type, TypeVar, Union
 
 from docstring_parser import Docstring, parse
 from packaging.version import Version
@@ -46,7 +47,7 @@ class _ArgData:
 
     name: str
 
-    annotation: Type
+    annotation: type
     "The type of values this argument accepts"
 
     is_required: bool
@@ -55,7 +56,7 @@ class _ArgData:
     default: Any
     "Value of the argument if the argument isn't passed in. This gets ignored if `is_required`"
 
-    description: Optional[str] = ""
+    description: str | None = ""
     "Human-readable description of the argument"
 
     is_positional_only: bool = False
@@ -68,7 +69,7 @@ class _TapData:
     Data about a class' or function's arguments which are sufficient to inform a Tap class.
     """
 
-    args_data: List[_ArgData]
+    args_data: list[_ArgData]
     "List of data about each argument in the class or function"
 
     has_kwargs: bool
@@ -78,14 +79,14 @@ class _TapData:
     "If true, ignore extra arguments and only parse known arguments"
 
 
-def _is_pydantic_base_model(obj: Union[Type[Any], Any]) -> bool:
-    if inspect.isclass(obj):  # issublcass requires that obj is a class
+def _is_pydantic_base_model(obj: type[Any] | Any) -> bool:
+    if inspect.isclass(obj):  # issubclass requires that obj is a class
         return issubclass(obj, BaseModel)
     else:
         return isinstance(obj, BaseModel)
 
 
-def _is_pydantic_dataclass(obj: Union[Type[Any], Any]) -> bool:
+def _is_pydantic_dataclass(obj: type[Any] | Any) -> bool:
     if _IS_PYDANTIC_V1:
         # There's no public function in v1. This is a somewhat safe but linear check
         return dataclasses.is_dataclass(obj) and any(key.startswith("__pydantic") for key in obj.__dict__)
@@ -94,7 +95,7 @@ def _is_pydantic_dataclass(obj: Union[Type[Any], Any]) -> bool:
 
 
 def _tap_data_from_data_model(
-    data_model: Any, func_kwargs: Dict[str, Any], param_to_description: Dict[str, str] = None
+    data_model: Any, func_kwargs: dict[str, Any], param_to_description: dict[str, str] | None = None
 ) -> _TapData:
     """
     Currently only works when `data_model` is a:
@@ -124,7 +125,7 @@ def _tap_data_from_data_model(
             description,
         )
 
-    def arg_data_from_pydantic(name: str, field: _PydanticField, annotation: Optional[Type] = None) -> _ArgData:
+    def arg_data_from_pydantic(name: str, field: _PydanticField, annotation: type | None = None) -> _ArgData:
         annotation = field.annotation if annotation is None else annotation
         # Prefer the description from param_to_description (from the data model / class docstring) over the
         # field.description b/c a docstring can be modified on the fly w/o causing real issues
@@ -153,7 +154,7 @@ def _tap_data_from_data_model(
     # dataclass fields in a pydantic BaseModel. It's also possible to use (builtin) dataclass fields and pydantic Fields
     # in the same data model. Therefore, the type of the data model doesn't determine the type of each field. The
     # solution is to iterate through the fields and check each type.
-    args_data: List[_ArgData] = []
+    args_data: list[_ArgData] = []
     for name, field in name_to_field.items():
         if isinstance(field, dataclasses.Field):
             # Idiosyncrasy: if a pydantic Field is used in a pydantic dataclass, then field.default is a FieldInfo
@@ -177,7 +178,7 @@ def _tap_data_from_data_model(
 
 
 def _tap_data_from_class_or_function(
-    class_or_function: _ClassOrFunction, func_kwargs: Dict[str, Any], param_to_description: Dict[str, str]
+    class_or_function: _ClassOrFunction, func_kwargs: dict[str, Any], param_to_description: dict[str, str]
 ) -> _TapData:
     """
     Extract data by inspecting the signature of `class_or_function`.
@@ -186,7 +187,7 @@ def _tap_data_from_class_or_function(
     ----
     Deletes redundant keys from `func_kwargs`
     """
-    args_data: List[_ArgData] = []
+    args_data: list[_ArgData] = []
     has_kwargs = False
     known_only = False
 
@@ -227,11 +228,11 @@ def _tap_data_from_class_or_function(
     return _TapData(args_data, has_kwargs, known_only)
 
 
-def _is_data_model(obj: Union[Type[Any], Any]) -> bool:
+def _is_data_model(obj: type[Any] | Any) -> bool:
     return dataclasses.is_dataclass(obj) or _is_pydantic_base_model(obj)
 
 
-def _docstring(class_or_function) -> Docstring:
+def _docstring(class_or_function: _ClassOrFunction) -> Docstring:
     is_function = not inspect.isclass(class_or_function)
     if is_function or _is_pydantic_base_model(class_or_function):
         doc = class_or_function.__doc__
@@ -240,7 +241,7 @@ def _docstring(class_or_function) -> Docstring:
     return parse(doc)
 
 
-def _tap_data(class_or_function: _ClassOrFunction, param_to_description: Dict[str, str], func_kwargs) -> _TapData:
+def _tap_data(class_or_function: _ClassOrFunction, param_to_description: dict[str, str], func_kwargs) -> _TapData:
     """
     Controls how :class:`_TapData` is extracted from `class_or_function`.
     """
@@ -258,7 +259,7 @@ def _tap_data(class_or_function: _ClassOrFunction, param_to_description: Dict[st
     return _tap_data_from_class_or_function(class_or_function, func_kwargs, param_to_description)
 
 
-def _tap_class(args_data: Sequence[_ArgData]) -> Type[Tap]:
+def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:
     """
     Transfers argument data to a :class:`tap.Tap` class. Arguments will be added to the parser on initialization.
     """
@@ -282,7 +283,7 @@ def _tap_class(args_data: Sequence[_ArgData]) -> Type[Tap]:
     return ArgParser
 
 
-def to_tap_class(class_or_function: _ClassOrFunction) -> Type[Tap]:
+def to_tap_class(class_or_function: _ClassOrFunction) -> type[Tap]:
     """Creates a `Tap` class from `class_or_function`. This can be subclassed to add custom argument handling and
     instantiated to create a typed argument parser.
 
@@ -296,11 +297,11 @@ def to_tap_class(class_or_function: _ClassOrFunction) -> Type[Tap]:
 
 
 def tapify(
-    class_or_function: Union[Callable[[InputType], OutputType], Type[OutputType]],
+    class_or_function: Callable[[InputType], OutputType] | type[OutputType],
     known_only: bool = False,
-    command_line_args: Optional[List[str]] = None,
+    command_line_args: list[str] | None = None,
     explicit_bool: bool = False,
-    description: Optional[str] = None,
+    description: str | None = None,
     **func_kwargs,
 ) -> OutputType:
     """Tapify initializes a class or runs a function by parsing arguments from the command line.
@@ -339,7 +340,7 @@ def tapify(
 
     # Prepare command line arguments for class_or_function, respecting positional-only args
     class_or_function_args: list[Any] = []
-    class_or_function_kwargs: Dict[str, Any] = {}
+    class_or_function_kwargs: dict[str, Any] = {}
     command_line_args_dict = command_line_args.as_dict()
     for arg_data in tap_data.args_data:
         arg_value = command_line_args_dict[arg_data.name]

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -338,7 +338,7 @@ def tapify(
     command_line_args: Tap = tap.parse_args(args=command_line_args, known_only=known_only)
 
     # Prepare command line arguments for class_or_function, respecting positional-only args
-    class_or_function_args: list[Any] = []
+    class_or_function_args: List[Any] = []
     class_or_function_kwargs: Dict[str, Any] = {}
     command_line_args_dict = command_line_args.as_dict()
     for arg_data in tap_data.args_data:

--- a/tap/tapify.py
+++ b/tap/tapify.py
@@ -4,11 +4,10 @@
 `to_tap_class`: convert a class or function into a `Tap` class, which can then be subclassed to add special argument
 handling
 """
-from __future__ import annotations
 
 import dataclasses
 import inspect
-from typing import Any, Callable, Sequence, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type, TypeVar, Union
 
 from docstring_parser import Docstring, parse
 from packaging.version import Version
@@ -47,7 +46,7 @@ class _ArgData:
 
     name: str
 
-    annotation: type
+    annotation: Type
     "The type of values this argument accepts"
 
     is_required: bool
@@ -56,7 +55,7 @@ class _ArgData:
     default: Any
     "Value of the argument if the argument isn't passed in. This gets ignored if `is_required`"
 
-    description: str | None = ""
+    description: Optional[str] = ""
     "Human-readable description of the argument"
 
     is_positional_only: bool = False
@@ -69,7 +68,7 @@ class _TapData:
     Data about a class' or function's arguments which are sufficient to inform a Tap class.
     """
 
-    args_data: list[_ArgData]
+    args_data: List[_ArgData]
     "List of data about each argument in the class or function"
 
     has_kwargs: bool
@@ -79,14 +78,14 @@ class _TapData:
     "If true, ignore extra arguments and only parse known arguments"
 
 
-def _is_pydantic_base_model(obj: type[Any] | Any) -> bool:
-    if inspect.isclass(obj):  # issubclass requires that obj is a class
+def _is_pydantic_base_model(obj: Union[Type[Any], Any]) -> bool:
+    if inspect.isclass(obj):  # issublcass requires that obj is a class
         return issubclass(obj, BaseModel)
     else:
         return isinstance(obj, BaseModel)
 
 
-def _is_pydantic_dataclass(obj: type[Any] | Any) -> bool:
+def _is_pydantic_dataclass(obj: Union[Type[Any], Any]) -> bool:
     if _IS_PYDANTIC_V1:
         # There's no public function in v1. This is a somewhat safe but linear check
         return dataclasses.is_dataclass(obj) and any(key.startswith("__pydantic") for key in obj.__dict__)
@@ -95,7 +94,7 @@ def _is_pydantic_dataclass(obj: type[Any] | Any) -> bool:
 
 
 def _tap_data_from_data_model(
-    data_model: Any, func_kwargs: dict[str, Any], param_to_description: dict[str, str] | None = None
+    data_model: Any, func_kwargs: Dict[str, Any], param_to_description: Dict[str, str] = None
 ) -> _TapData:
     """
     Currently only works when `data_model` is a:
@@ -125,7 +124,7 @@ def _tap_data_from_data_model(
             description,
         )
 
-    def arg_data_from_pydantic(name: str, field: _PydanticField, annotation: type | None = None) -> _ArgData:
+    def arg_data_from_pydantic(name: str, field: _PydanticField, annotation: Optional[Type] = None) -> _ArgData:
         annotation = field.annotation if annotation is None else annotation
         # Prefer the description from param_to_description (from the data model / class docstring) over the
         # field.description b/c a docstring can be modified on the fly w/o causing real issues
@@ -154,7 +153,7 @@ def _tap_data_from_data_model(
     # dataclass fields in a pydantic BaseModel. It's also possible to use (builtin) dataclass fields and pydantic Fields
     # in the same data model. Therefore, the type of the data model doesn't determine the type of each field. The
     # solution is to iterate through the fields and check each type.
-    args_data: list[_ArgData] = []
+    args_data: List[_ArgData] = []
     for name, field in name_to_field.items():
         if isinstance(field, dataclasses.Field):
             # Idiosyncrasy: if a pydantic Field is used in a pydantic dataclass, then field.default is a FieldInfo
@@ -178,7 +177,7 @@ def _tap_data_from_data_model(
 
 
 def _tap_data_from_class_or_function(
-    class_or_function: _ClassOrFunction, func_kwargs: dict[str, Any], param_to_description: dict[str, str]
+    class_or_function: _ClassOrFunction, func_kwargs: Dict[str, Any], param_to_description: Dict[str, str]
 ) -> _TapData:
     """
     Extract data by inspecting the signature of `class_or_function`.
@@ -187,7 +186,7 @@ def _tap_data_from_class_or_function(
     ----
     Deletes redundant keys from `func_kwargs`
     """
-    args_data: list[_ArgData] = []
+    args_data: List[_ArgData] = []
     has_kwargs = False
     known_only = False
 
@@ -228,11 +227,11 @@ def _tap_data_from_class_or_function(
     return _TapData(args_data, has_kwargs, known_only)
 
 
-def _is_data_model(obj: type[Any] | Any) -> bool:
+def _is_data_model(obj: Union[Type[Any], Any]) -> bool:
     return dataclasses.is_dataclass(obj) or _is_pydantic_base_model(obj)
 
 
-def _docstring(class_or_function: _ClassOrFunction) -> Docstring:
+def _docstring(class_or_function) -> Docstring:
     is_function = not inspect.isclass(class_or_function)
     if is_function or _is_pydantic_base_model(class_or_function):
         doc = class_or_function.__doc__
@@ -241,7 +240,7 @@ def _docstring(class_or_function: _ClassOrFunction) -> Docstring:
     return parse(doc)
 
 
-def _tap_data(class_or_function: _ClassOrFunction, param_to_description: dict[str, str], func_kwargs) -> _TapData:
+def _tap_data(class_or_function: _ClassOrFunction, param_to_description: Dict[str, str], func_kwargs) -> _TapData:
     """
     Controls how :class:`_TapData` is extracted from `class_or_function`.
     """
@@ -259,7 +258,7 @@ def _tap_data(class_or_function: _ClassOrFunction, param_to_description: dict[st
     return _tap_data_from_class_or_function(class_or_function, func_kwargs, param_to_description)
 
 
-def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:
+def _tap_class(args_data: Sequence[_ArgData]) -> Type[Tap]:
     """
     Transfers argument data to a :class:`tap.Tap` class. Arguments will be added to the parser on initialization.
     """
@@ -283,7 +282,7 @@ def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:
     return ArgParser
 
 
-def to_tap_class(class_or_function: _ClassOrFunction) -> type[Tap]:
+def to_tap_class(class_or_function: _ClassOrFunction) -> Type[Tap]:
     """Creates a `Tap` class from `class_or_function`. This can be subclassed to add custom argument handling and
     instantiated to create a typed argument parser.
 
@@ -297,11 +296,11 @@ def to_tap_class(class_or_function: _ClassOrFunction) -> type[Tap]:
 
 
 def tapify(
-    class_or_function: Callable[[InputType], OutputType] | type[OutputType],
+    class_or_function: Union[Callable[[InputType], OutputType], Type[OutputType]],
     known_only: bool = False,
-    command_line_args: list[str] | None = None,
+    command_line_args: Optional[List[str]] = None,
     explicit_bool: bool = False,
-    description: str | None = None,
+    description: Optional[str] = None,
     **func_kwargs,
 ) -> OutputType:
     """Tapify initializes a class or runs a function by parsing arguments from the command line.
@@ -340,7 +339,7 @@ def tapify(
 
     # Prepare command line arguments for class_or_function, respecting positional-only args
     class_or_function_args: list[Any] = []
-    class_or_function_kwargs: dict[str, Any] = {}
+    class_or_function_kwargs: Dict[str, Any] = {}
     command_line_args_dict = command_line_args.as_dict()
     for arg_data in tap_data.args_data:
         arg_value = command_line_args_dict[arg_data.name]

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -124,7 +124,7 @@ def type_to_str(type_annotation: Union[type, Any]) -> str:
     :return: A string representation of the type annotation.
     """
     # Built-in type
-    if type(type_annotation) == type:
+    if type(type_annotation) is type:
         return type_annotation.__name__
 
     # Typing type
@@ -309,7 +309,7 @@ class TupleTypeEnforcer:
     """The type argument to argparse for checking and applying types to Tuples."""
 
     def __init__(self, types: List[type], loop: bool = False):
-        self.types = [boolean_type if t == bool else t for t in types]
+        self.types = [boolean_type if t is bool else t for t in types]
         self.loop = loop
         self.index = 0
 

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -24,7 +24,7 @@ from typing import (
     Union,
     TypedDict,
 )
-a
+
 from typing import get_args, get_origin as typing_get_origin
 
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -430,9 +430,6 @@ def fix_py36_copy(func: Callable) -> Callable:
 
     Based on https://stackoverflow.com/questions/6279305/typeerror-cannot-deepcopy-this-pattern-object
     """
-    if sys.version_info[:2] > (3, 6):
-        return func
-
     @wraps(func)
     def wrapper(*args, **kwargs):
         re_type = type(re.compile(""))

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -16,6 +16,7 @@ from typing import (
     Generator,
     Iterator,
     List,
+    Type,
     Literal,
     Optional,
     Tuple,
@@ -395,8 +396,11 @@ def _nested_replace_type(obj: Any, find_type: type, replace_type: type) -> Any:
 
     return obj
 
+class _PythonObjectEncoderProto(Protocol):
+    def iterencode(self, o: Any, _one_shot: bool = False) -> Iterator[str]: ...
+    def default(self, obj: Any) -> Any: ...
 
-def define_python_object_encoder(skip_unpicklable: bool = False) -> "PythonObjectEncoder":  # noqa F821
+def define_python_object_encoder(skip_unpicklable: bool = False) -> Type[_PythonObjectEncoderProto]:
     class PythonObjectEncoder(JSONEncoder):
         """Stores parameters that are not JSON serializable as pickle dumps.
 
@@ -480,7 +484,9 @@ ReproducibilityInfo = Union[_ReproducibilityInfo, ReproducibilityInfoWithGit]
 
 
 def enforce_reproducibility(
-    saved_reproducibility_data: Optional[ReproducibilityInfo], current_reproducibility_data: Dict[str, str], path: PathLike
+    saved_reproducibility_data: Optional[ReproducibilityInfo],
+    current_reproducibility_data: ReproducibilityInfo,
+    path: PathLike,
 ) -> None:
     """Checks if reproducibility has failed and raises the appropriate error.
 

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -31,14 +31,15 @@ NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
 PRIMITIVES = (str, int, float, bool)
 PathLike = Union[str, os.PathLike]
 
-def is_literal_type(tp: type) -> bool:
-    """Returns whether the type is a literal type."""
-    return tp is Literal or getattr(tp, "__origin__", None) is Literal
-
 def get_origin(tp: type) -> type:
     """Same as typing.get_origin but returns the type itself if the origin is None."""
     origin = typing_get_origin(tp)
     return origin if origin is not None else tp
+
+def is_literal_type(tp: type) -> bool:
+    """Returns whether the type is a literal type."""
+    return tp is Literal or get_origin(tp) is Literal
+
 
 def check_output(command: List[str], suppress_stderr: bool = True, **kwargs) -> str:
     """Runs subprocess.check_output and returns the result as a string.

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -57,9 +57,10 @@ class GitInfo:
         """
         try:
             output = check_output(["git", "rev-parse", "--is-inside-work-tree"], cwd=self.repo_path)
-            return output == "true"
         except (FileNotFoundError, subprocess.CalledProcessError):
             return False
+        else:
+            return output == "true"
 
     def get_git_root(self) -> str:
         """Gets the root directory of the git repo where the command is run.
@@ -196,6 +197,8 @@ def get_class_column(obj: type) -> int:
             continue
 
         return start_column
+
+    raise ValueError("Could not find class column")
 
 def source_line_to_tokens(obj: object) -> dict[int, list[dict[str, str | int]]]:
     """Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code."""
@@ -385,7 +388,7 @@ def define_python_object_encoder(skip_unpicklable: bool = False) -> "PythonObjec
                         f"Could not pickle this object: Failed with exception {e}\n"
                         f"If you would like to ignore unpicklable attributes set "
                         f"skip_unpicklable = True in save."
-                    )
+                    ) from e
                 else:
                     return {"_type": f"unpicklable_object {obj.__class__.__name__}", "_value": None}
 
@@ -393,7 +396,7 @@ def define_python_object_encoder(skip_unpicklable: bool = False) -> "PythonObjec
 
 
 class UnpicklableObject:
-    """A class that serves as a placeholder for an object that could not be pickled. """
+    """A class that serves as a placeholder for an object that could not be pickled."""
 
     def __eq__(self, other):
         return isinstance(other, UnpicklableObject)

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -431,29 +431,6 @@ def as_python_object(dct: Any) -> Any:
     return dct
 
 
-def fix_py36_copy(func: Callable) -> Callable:
-    """Decorator that fixes functions using Python 3.6 deepcopy of ArgumentParsers.
-
-    Based on https://stackoverflow.com/questions/6279305/typeerror-cannot-deepcopy-this-pattern-object
-    """
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        re_type = type(re.compile(""))
-        has_prev_val = re_type in copy._deepcopy_dispatch
-        prev_val = copy._deepcopy_dispatch.get(re_type, None)
-        copy._deepcopy_dispatch[type(re.compile(""))] = lambda r, _: r
-
-        result = func(*args, **kwargs)
-
-        if has_prev_val:
-            copy._deepcopy_dispatch[re_type] = prev_val
-        else:
-            del copy._deepcopy_dispatch[re_type]
-
-        return result
-
-    return wrapper
-
 class _ReproducibilityInfo(TypedDict):
     command_line: str
     time: str

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -21,10 +21,7 @@ from typing import (
     Literal,
     Union,
 )
-from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
-
-if sys.version_info >= (3, 10):
-    from types import UnionType
+from typing_inspect import get_args
 
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
 PRIMITIVES = (str, int, float, bool)
@@ -486,28 +483,3 @@ def enforce_reproducibility(
 
     if current_reproducibility_data["git_has_uncommitted_changes"]:
         raise ValueError(f"{no_reproducibility_message}: Uncommitted changes " f"in current args.")
-
-
-# TODO: remove this once typing_inspect.get_origin is fixed for Python 3.8, 3.9, and 3.10
-# https://github.com/ilevkivskyi/typing_inspect/issues/64
-# https://github.com/ilevkivskyi/typing_inspect/issues/65
-def get_origin(tp: Any) -> Any:
-    """Same as typing_inspect.get_origin but fixes parameterized generic types like Set."""
-    origin = typing_inspect_get_origin(tp)
-
-    if origin is None:
-        origin = tp
-
-    if sys.version_info >= (3, 10) and isinstance(origin, UnionType):
-        origin = UnionType
-
-    return origin
-
-
-# TODO: remove this once typing_inspect.get_args is fixed for Python 3.10 union types
-def get_args(tp: Any) -> tuple[type, ...]:
-    """Same as typing_inspect.get_args but fixes Python 3.10 union types."""
-    if sys.version_info >= (3, 10) and isinstance(tp, UnionType):
-        return tp.__args__
-
-    return typing_inspect_get_args(tp)

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from argparse import ArgumentParser, ArgumentTypeError
 from base64 import b64encode, b64decode
 from dataclasses import dataclass
@@ -14,9 +12,13 @@ import tokenize
 from typing import (
     Any,
     Callable,
+    Dict,
     Generator,
     Iterator,
+    List,
     Literal,
+    Optional,
+    Tuple,
     Protocol,
     Union,
     TypedDict,
@@ -28,7 +30,7 @@ PRIMITIVES = (str, int, float, bool)
 PathLike = Union[str, os.PathLike]
 
 
-def check_output(command: list[str], suppress_stderr: bool = True, **kwargs) -> str:
+def check_output(command: List[str], suppress_stderr: bool = True, **kwargs) -> str:
     """Runs subprocess.check_output and returns the result as a string.
 
     :param command: A list of strings representing the command to run on the command line.
@@ -112,7 +114,7 @@ class GitInfo:
         return not status.endswith(NO_CHANGES_STATUS)
 
 
-def type_to_str(type_annotation: type | Any) -> str:
+def type_to_str(type_annotation: Union[type, Any]) -> str:
     """Gets a string representation of the provided type.
 
     :param type_annotation: A type annotation, which is either a built-in type or a typing type.
@@ -213,6 +215,7 @@ def get_class_column(obj: object) -> int:
 
     raise ValueError("Could not find class column")
 
+
 class TokenInfoDict(TypedDict):
     # Almost a copy of tokenize.TokenInfo, but a TypedDict instead of a NamedTuple
     # and start and end are directly accessible instead of being in a tuple
@@ -224,7 +227,8 @@ class TokenInfoDict(TypedDict):
     end_column: int
     line: str
 
-def source_line_to_tokens(obj: object) -> dict[int, list[TokenInfoDict]]:
+
+def source_line_to_tokens(obj: object) -> Dict[int, List[TokenInfoDict]]:
     """Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code."""
     line_to_tokens = {}
     for token_type, token, (start_line, start_column), (end_line, end_column), line in tokenize_source(obj):
@@ -300,7 +304,7 @@ def get_class_variables(cls: type) -> ClassVariableContainer:
     return variable_to_comment
 
 
-def get_literals(literal: type[Literal], variable: str) -> tuple[Callable[[str], Any], list[str]]:
+def get_literals(literal: Literal, variable: str) -> Tuple[Callable[[str], Any], List[str]]:
     """Extracts the values from a Literal type and ensures that the values are all primitive types."""
     literals = list(get_args(literal))
 
@@ -341,8 +345,7 @@ class _ConverterFromStr(Protocol):
 class TupleTypeEnforcer:
     """The type argument to argparse for checking and applying types to Tuples."""
 
-
-    def __init__(self, types: list[_ConverterFromStr], loop: bool = False):
+    def __init__(self, types: List[type], loop: bool = False):
         self.types = [boolean_type if t is bool else t for t in types]
         self.loop = loop
         self.index = 0
@@ -477,7 +480,7 @@ ReproducibilityInfo = Union[_ReproducibilityInfo, ReproducibilityInfoWithGit]
 
 
 def enforce_reproducibility(
-    saved_reproducibility_data: ReproducibilityInfo | None, current_reproducibility_data: ReproducibilityInfo, path: PathLike
+    saved_reproducibility_data: Optional[ReproducibilityInfo], current_reproducibility_data: dict[str, str], path: PathLike
 ) -> None:
     """Checks if reproducibility has failed and raises the appropriate error.
 

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from argparse import ArgumentParser, ArgumentTypeError
 from base64 import b64encode, b64decode
 import copy
@@ -14,13 +16,9 @@ import tokenize
 from typing import (
     Any,
     Callable,
-    Dict,
     Generator,
     Iterator,
-    List,
     Literal,
-    Optional,
-    Tuple,
     Union,
 )
 from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
@@ -33,7 +31,7 @@ PRIMITIVES = (str, int, float, bool)
 PathLike = Union[str, os.PathLike]
 
 
-def check_output(command: List[str], suppress_stderr: bool = True, **kwargs) -> str:
+def check_output(command: list[str], suppress_stderr: bool = True, **kwargs) -> str:
     """Runs subprocess.check_output and returns the result as a string.
 
     :param command: A list of strings representing the command to run on the command line.
@@ -117,7 +115,7 @@ class GitInfo:
         return not status.endswith(NO_CHANGES_STATUS)
 
 
-def type_to_str(type_annotation: Union[type, Any]) -> str:
+def type_to_str(type_annotation: type | Any) -> str:
     """Gets a string representation of the provided type.
 
     :param type_annotation: A type annotation, which is either a built-in type or a typing type.
@@ -199,8 +197,7 @@ def get_class_column(obj: type) -> int:
 
         return start_column
 
-
-def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, int]]]]:
+def source_line_to_tokens(obj: object) -> dict[int, list[dict[str, str | int]]]:
     """Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code."""
     line_to_tokens = {}
     for token_type, token, (start_line, start_column), (end_line, end_column), line in tokenize_source(obj):
@@ -219,7 +216,7 @@ def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, in
     return line_to_tokens
 
 
-def get_class_variables(cls: type) -> Dict[str, Dict[str, str]]:
+def get_class_variables(cls: type) -> dict[str, dict[str, str]]:
     """Returns a dictionary mapping class variables to their additional information (currently just comments)."""
     # Get mapping from line number to tokens
     line_to_tokens = source_line_to_tokens(cls)
@@ -271,7 +268,7 @@ def get_class_variables(cls: type) -> Dict[str, Dict[str, str]]:
     return variable_to_comment
 
 
-def get_literals(literal: Literal, variable: str) -> Tuple[Callable[[str], Any], List[str]]:
+def get_literals(literal: type[Literal], variable: str) -> tuple[Callable[[str], Any], list[str]]:
     """Extracts the values from a Literal type and ensures that the values are all primitive types."""
     literals = list(get_args(literal))
 
@@ -308,7 +305,7 @@ def boolean_type(flag_value: str) -> bool:
 class TupleTypeEnforcer:
     """The type argument to argparse for checking and applying types to Tuples."""
 
-    def __init__(self, types: List[type], loop: bool = False):
+    def __init__(self, types: list[type], loop: bool = False):
         self.types = [boolean_type if t is bool else t for t in types]
         self.loop = loop
         self.index = 0
@@ -387,7 +384,7 @@ def define_python_object_encoder(skip_unpicklable: bool = False) -> "PythonObjec
                     raise ValueError(
                         f"Could not pickle this object: Failed with exception {e}\n"
                         f"If you would like to ignore unpicklable attributes set "
-                        f"skip_unpickleable = True in save."
+                        f"skip_unpicklable = True in save."
                     )
                 else:
                     return {"_type": f"unpicklable_object {obj.__class__.__name__}", "_value": None}
@@ -456,7 +453,7 @@ def fix_py36_copy(func: Callable) -> Callable:
 
 
 def enforce_reproducibility(
-    saved_reproducibility_data: Optional[Dict[str, str]], current_reproducibility_data: Dict[str, str], path: PathLike
+    saved_reproducibility_data: dict[str, str] | None, current_reproducibility_data: dict[str, str], path: PathLike
 ) -> None:
     """Checks if reproducibility has failed and raises the appropriate error.
 
@@ -495,7 +492,7 @@ def enforce_reproducibility(
 # https://github.com/ilevkivskyi/typing_inspect/issues/64
 # https://github.com/ilevkivskyi/typing_inspect/issues/65
 def get_origin(tp: Any) -> Any:
-    """Same as typing_inspect.get_origin but fixes unparameterized generic types like Set."""
+    """Same as typing_inspect.get_origin but fixes parameterized generic types like Set."""
     origin = typing_inspect_get_origin(tp)
 
     if origin is None:
@@ -508,7 +505,7 @@ def get_origin(tp: Any) -> Any:
 
 
 # TODO: remove this once typing_inspect.get_args is fixed for Python 3.10 union types
-def get_args(tp: Any) -> Tuple[type, ...]:
+def get_args(tp: Any) -> tuple[type, ...]:
     """Same as typing_inspect.get_args but fixes Python 3.10 union types."""
     if sys.version_info >= (3, 10) and isinstance(tp, UnionType):
         return tp.__args__

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -22,8 +22,8 @@ from typing import (
     Protocol,
     Union,
     TypedDict,
+    get_args,
 )
-from typing_inspect import get_args
 
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
 PRIMITIVES = (str, int, float, bool)
@@ -250,7 +250,7 @@ class ClassVariableInfo(TypedDict):
     comment: str
 
 class ClassVariableContainer(TypedDict):
-    class_variables: dict[str, ClassVariableInfo]
+    class_variables: Dict[str, ClassVariableInfo]
 
 def get_class_variables(cls: type) -> ClassVariableContainer:
     """Returns a dictionary mapping class variables to their additional information (currently just comments)."""
@@ -480,7 +480,7 @@ ReproducibilityInfo = Union[_ReproducibilityInfo, ReproducibilityInfoWithGit]
 
 
 def enforce_reproducibility(
-    saved_reproducibility_data: Optional[ReproducibilityInfo], current_reproducibility_data: dict[str, str], path: PathLike
+    saved_reproducibility_data: Optional[ReproducibilityInfo], current_reproducibility_data: Dict[str, str], path: PathLike
 ) -> None:
     """Checks if reproducibility has failed and raises the appropriate error.
 

--- a/tap/utils.py
+++ b/tap/utils.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from argparse import ArgumentParser, ArgumentTypeError
 from base64 import b64encode, b64decode
-import copy
-from functools import wraps
 import inspect
 from io import StringIO
 from json import JSONEncoder


### PR DESCRIPTION
Some code must have been added before Python 3.8. We can put this version to good use. These fixes do not modify the runtime in any way.

Changes:
- 2 or 3 typos
- No need to use inspect_typing, there is built-in functions in the typing module to replace them (exactly the same code)
- More precise type hints: use of `typing.Protocol` and `typing.TypedDict` instead of bare dict, callable or types
- Remove old code only used in Python < 3.8

I think it is possible to go much further in type annotation (e.g. by annotating some methods with *args and **kwargs). But for this, [typing-extensions](https://github.com/python/typing_extensions) must be added as a dependency.

I thought for a long time that using `from __future__ import annotations` to use `dict[str | int, int] | List[str |int]` instead of `Union[Dict[Union[str, int], int], List[Union[str, int]]` would be a good idea, but the package itself does not support this syntax so it would only be an additional source of bugs.