### PR TITLE
replace tokenize with ast to parse the source code

### DIFF
--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -229,7 +229,6 @@ def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, in
 class _ClassVariableInfo(NamedTuple):
     name: str
     doc: str
-    start_line: int
     end_line: int
 
 
@@ -237,9 +236,9 @@ def _get_comments(source_code: str) -> Dict[int, str]:
     """Get comments from a source code, with line numbers as keys."""
     source_io = io.StringIO(source_code)
     tokens = tokenize.generate_tokens(source_io.readline)
-    # dict with line numbers as keys and comments as values
     return {
-        token.start[0]: token.string
+        # line number : comment without the '#' and trailing whitespaces
+        token.start[0]: token.string[1:].strip()
         for token in tokens
         if token.type == tokenize.COMMENT
     }
@@ -298,10 +297,8 @@ def _get_class_variable(
     if last_line is None:
         last_line = first_line
 
-    # remove the comment character and remove leading/trailing whitespaces
-    # so that "# comment" becomes "comment"
-    comment = comments.get(last_line, "")[1:].strip()
-    return _ClassVariableInfo(name, comment, first_line, last_line)
+    comment = comments.get(last_line, "")
+    return _ClassVariableInfo(name, comment, last_line)
 
 
 def _add_possible_doc(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,24 +1,24 @@
-from argparse import ArgumentTypeError
 import json
 import os
 import subprocess
-from tempfile import TemporaryDirectory
-from typing import Any, Callable, List, Literal, Dict, Set, Tuple, Union
 import unittest
+from argparse import ArgumentTypeError
+from tempfile import TemporaryDirectory
+from typing import Any, Callable, Dict, List, Literal, Set, Tuple, Union
 from unittest import TestCase
 
 from tap.utils import (
+    GitInfo,
+    TupleTypeEnforcer,
+    UnpicklableObject,
+    _nested_replace_type,
+    as_python_object,
+    define_python_object_encoder,
+    enforce_reproducibility,
     get_class_column,
     get_class_variables,
-    GitInfo,
-    type_to_str,
     get_literals,
-    TupleTypeEnforcer,
-    _nested_replace_type,
-    define_python_object_encoder,
-    UnpicklableObject,
-    as_python_object,
-    enforce_reproducibility,
+    type_to_str,
 )
 
 
@@ -330,6 +330,28 @@ T
 
         class_variables = {"arg": {"comment": ""}}
         self.assertEqual(get_class_variables(DataclassColumn), class_variables)
+
+    def test_multiline_argument(self):
+        class MultilineArgument:
+            bar: str = (
+                "This is a multiline argument"
+                " that should not be included in the docstring"
+            )
+            """biz baz"""
+
+        class_variables = {"bar": {"comment": "biz baz"}}
+        self.assertEqual(get_class_variables(MultilineArgument), class_variables)
+
+    def test_comments_with_quotes(self):
+        class MultiquoteMultiline:
+            bar: int = 0
+            '\'\'biz baz\''
+
+            hi: str
+            "\"Hello there\"\""
+
+        class_variables = {"bar": {"comment": "''biz baz"}, "hi": {"comment": '"Hello there""'}}
+        self.assertEqual(get_class_variables(MultiquoteMultiline), class_variables)
 
 
 class GetLiteralsTests(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -350,7 +350,7 @@ T
             hi: str
             "\"Hello there\"\""
 
-        class_variables = {"bar": {"comment": "''biz baz"}, "hi": {"comment": '"Hello there""'}}
+        class_variables = {"bar": {"comment": "''biz baz'"}, "hi": {"comment": '"Hello there""'}}
         self.assertEqual(get_class_variables(MultiquoteMultiline), class_variables)
 
 


### PR DESCRIPTION
Instead of parsing by hand token by token, ast returns a python object that just needs to be read. We can still make mistakes when reading this object, but no more inevitable edge cases from parsing the source code.

Closes #97
Closes #130