### PR TITLE
fix #99: allow no git remote

### DIFF
--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -370,7 +370,7 @@ class Tap(ArgumentParser):
         pass
 
     @staticmethod
-    def get_reproducibility_info(repo_path: Optional[PathLike] = None) -> Dict[str, str]:
+    def get_reproducibility_info(repo_path: Optional[PathLike] = None) -> Dict[str, Optional[str]]:
         """Gets a dictionary of reproducibility information.
 
         Reproducibility information always includes:
@@ -380,7 +380,8 @@ class Tap(ArgumentParser):
         If git is installed, reproducibility information also includes:
         - git_root: The root of the git repo where the command is run.
         - git_url: The url of the current hash of the git repo where the command is run.
-                   Ex. https://github.com/swansonk14/rationale-alignment/tree/<hash>
+                   Ex. https://github.com/swansonk14/rationale-alignment/tree/<hash>.
+                   If it is a local repo, the url is None.
         - git_has_uncommitted_changes: Whether the current git repo has uncommitted changes.
 
         :param repo_path: Path to the git repo to examine for reproducibility info.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,6 +108,17 @@ class GitTests(TestCase):
         url = f"{true_url}/tree/"
         self.assertEqual(self.git_info.get_git_url(commit_hash=True)[: len(url)], url)
 
+    def test_get_git_url_no_remote(self) -> None:
+        subprocess.run(["git", "remote", "remove", "origin"])
+        self.assertIsNone(self.git_info.get_git_url())
+
+    def test_get_git_version(self) -> None:
+        git_version = self.git_info.get_git_version()
+        self.assertEqual(len(git_version), 3)
+        self.assertIsInstance(git_version, tuple)
+        for v in git_version:
+            self.assertIsInstance(v, int)
+
     def test_has_uncommitted_changes_false(self) -> None:
         self.assertFalse(self.git_info.has_uncommitted_changes())
 


### PR DESCRIPTION
Fix #99.

The return value in `get_git_url` and the value of `reproducibility["git_url"]` can now be `None` if it is a git repo with no remote.