### PR TITLE
Improve performance

### DIFF
--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -483,9 +483,7 @@ class Tap(ArgumentParser):
         return self
 
     @classmethod
-    def _get_from_self_and_super(
-        cls, extract_func: Callable[[type], dict], *, need_tap_cls: bool = True,
-    ) -> Union[Dict[str, Any], Dict]:
+    def _get_from_self_and_super( cls, extract_func: Callable[[type], dict]) -> Union[Dict[str, Any], Dict]:
         """Returns a dictionary mapping variable names to values.
 
         Variables and values are extracted from classes using key starting
@@ -496,7 +494,6 @@ class Tap(ArgumentParser):
         Super classes are traversed through breadth first search.
 
         :param extract_func: A function that extracts from a class a dictionary mapping variables to values.
-        :param need_tap_cls: If False, variables from the Tap and ArgumentParser classes are ignored.
         :return: A dictionary mapping variable names to values from the class dict.
         """
         visited = set()
@@ -506,10 +503,7 @@ class Tap(ArgumentParser):
         while len(super_classes) > 0:
             super_class = super_classes.pop(0)
 
-            if not need_tap_cls and super_class is Tap:
-                break
-
-            if super_class not in visited and issubclass(super_class, Tap):
+            if super_class not in visited and issubclass(super_class, Tap) and super_class is not Tap:
                 super_dictionary = extract_func(super_class)
 
                 # Update only unseen variables to avoid overriding subclass values
@@ -527,8 +521,7 @@ class Tap(ArgumentParser):
     def _get_class_dict(self) -> Dict[str, Any]:
         """Returns a dictionary mapping class variable names to values from the class dict."""
         class_dict = self._get_from_self_and_super(
-            extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict())),
-            need_tap_cls=False,
+            extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict()))
         )
         class_dict = {
             var: val
@@ -545,8 +538,7 @@ class Tap(ArgumentParser):
     def _get_annotations(self) -> Dict[str, Any]:
         """Returns a dictionary mapping variable names to their type annotations."""
         return self._get_from_self_and_super(
-            extract_func=lambda super_class: dict(get_type_hints(super_class)),
-            need_tap_cls=False,
+            extract_func=lambda super_class: dict(get_type_hints(super_class))
         )
 
     def _get_class_variables(self) -> dict:
@@ -554,9 +546,7 @@ class Tap(ArgumentParser):
         class_variable_names = {**self._get_annotations(), **self._get_class_dict()}.keys()
 
         try:
-            class_variables = self._get_from_self_and_super(
-                extract_func=get_class_variables, need_tap_cls=False,
-            )
+            class_variables = self._get_from_self_and_super(extract_func=get_class_variables)
 
             # Handle edge-case of source code modification while code is running
             variables_to_add = class_variable_names - class_variables.keys()
@@ -597,7 +587,6 @@ class Tap(ArgumentParser):
         self_dict = self.__dict__
         class_dict = self._get_from_self_and_super(
             extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict())),
-            need_tap_cls=False,
         )
         class_dict = {key: val for key, val in class_dict.items() if key not in self_dict}
         stored_dict = {**self_dict, **class_dict}

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -483,7 +483,7 @@ class Tap(ArgumentParser):
         return self
 
     @classmethod
-    def _get_from_self_and_super( cls, extract_func: Callable[[type], dict]) -> Union[Dict[str, Any], Dict]:
+    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> Union[Dict[str, Any], Dict]:
         """Returns a dictionary mapping variable names to values.
 
         Variables and values are extracted from classes using key starting
@@ -537,9 +537,7 @@ class Tap(ArgumentParser):
 
     def _get_annotations(self) -> Dict[str, Any]:
         """Returns a dictionary mapping variable names to their type annotations."""
-        return self._get_from_self_and_super(
-            extract_func=lambda super_class: dict(get_type_hints(super_class))
-        )
+        return self._get_from_self_and_super(extract_func=lambda super_class: dict(get_type_hints(super_class)))
 
     def _get_class_variables(self) -> dict:
         """Returns a dictionary mapping class variables names to their additional information."""
@@ -586,7 +584,7 @@ class Tap(ArgumentParser):
 
         self_dict = self.__dict__
         class_dict = self._get_from_self_and_super(
-            extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict())),
+            extract_func=lambda super_class: dict(getattr(super_class, "__dict__", dict()))
         )
         class_dict = {key: val for key, val in class_dict.items() if key not in self_dict}
         stored_dict = {**self_dict, **class_dict}

--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -185,17 +185,12 @@ def is_positional_arg(*name_or_flags) -> bool:
     return not is_option_arg(*name_or_flags)
 
 
-def _tokenize_source(source: str) -> Generator[tokenize.TokenInfo, None, None]:
+def tokenize_source(source: str) -> Generator[tokenize.TokenInfo, None, None]:
     """Returns a generator for the tokens of the object's source code, given the source code."""
     return tokenize.generate_tokens(StringIO(source).readline)
 
 
-def tokenize_source(obj: object) -> Generator:
-    """Returns a generator for the tokens of the object's source code."""
-    return _tokenize_source(inspect.getsource(obj))
-
-
-def _get_class_column(tokens: Iterable[tokenize.TokenInfo]) -> int:
+def get_class_column(tokens: Iterable[tokenize.TokenInfo]) -> int:
     """Determines the column number for class variables in a class, given the tokens of the class."""
     first_line = 1
     for token_type, token, (start_line, start_column), (end_line, end_column), line in tokens:
@@ -205,14 +200,10 @@ def _get_class_column(tokens: Iterable[tokenize.TokenInfo]) -> int:
             continue
 
         return start_column
+    raise ValueError("Could not find any class variables in the class.")
 
 
-def get_class_column(cls: type) -> int:
-    """Determines the column number for class variables in a class."""
-    return _get_class_column(tokenize_source(cls))
-
-
-def _source_line_to_tokens(tokens: Iterable[tokenize.TokenInfo]) -> Dict[int, List[Dict[str, Union[str, int]]]]:
+def source_line_to_tokens(tokens: Iterable[tokenize.TokenInfo]) -> Dict[int, List[Dict[str, Union[str, int]]]]:
     """
     Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code,
     given the tokens of the object's source code.
@@ -232,12 +223,7 @@ def _source_line_to_tokens(tokens: Iterable[tokenize.TokenInfo]) -> Dict[int, Li
     return line_to_tokens
 
 
-def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, int]]]]:
-    """Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code."""
-    return _source_line_to_tokens(tokenize_source(obj))
-
-
-def _get_subsequent_assign_lines(source_cls: str) -> Set[int]:
+def get_subsequent_assign_lines(source_cls: str) -> Set[int]:
     """
     For all multiline assign statements, get the line numbers after the first line of the assignment,
     given the source code of the object.
@@ -283,25 +269,22 @@ def _get_subsequent_assign_lines(source_cls: str) -> Set[int]:
 
     return assign_lines
 
-def get_subsequent_assign_lines(cls: type) -> Set[int]:
-    """For all multiline assign statements, get the line numbers after the first line of the assignment."""
-    return _get_subsequent_assign_lines(inspect.getsource(cls))
 
 def get_class_variables(cls: type) -> Dict[str, Dict[str, str]]:
     """Returns a dictionary mapping class variables to their additional information (currently just comments)."""
     # Get the source code and tokens of the class
     source_cls = inspect.getsource(cls)
-    tokens = tuple(_tokenize_source(source_cls))
+    tokens = tuple(tokenize_source(source_cls))
 
     # Get mapping from line number to tokens
-    line_to_tokens = _source_line_to_tokens(tokens)
+    line_to_tokens = source_line_to_tokens(tokens)
 
     # Get class variable column number
-    class_variable_column = _get_class_column(tokens)
+    class_variable_column = get_class_column(tokens)
 
     # For all multiline assign statements, get the line numbers after the first line of the assignment
     # This is used to avoid identifying comments in multiline assign statements
-    subsequent_assign_lines = _get_subsequent_assign_lines(source_cls)
+    subsequent_assign_lines = get_subsequent_assign_lines(source_cls)
 
     # Extract class variables
     class_variable = None

--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -267,7 +267,7 @@ def get_subsequent_assign_lines(source_cls: str) -> Set[int]:
             # Check if the end line number is found
             if node.end_lineno is None:
                 warnings.warn(parse_warning)
-                return set()
+                continue
 
             # Get line number of assign statement excluding the first line (and minus 1 for the if statement)
             assign_lines |= set(range(node.lineno, node.end_lineno))

--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -18,6 +18,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     Iterator,
     List,
     Literal,
@@ -184,17 +185,20 @@ def is_positional_arg(*name_or_flags) -> bool:
     return not is_option_arg(*name_or_flags)
 
 
+def _tokenize_source(source: str) -> Generator[tokenize.TokenInfo, None, None]:
+    """Returns a generator for the tokens of the object's source code, given the source code."""
+    return tokenize.generate_tokens(StringIO(source).readline)
+
+
 def tokenize_source(obj: object) -> Generator:
     """Returns a generator for the tokens of the object's source code."""
-    source = inspect.getsource(obj)
-    token_generator = tokenize.generate_tokens(StringIO(source).readline)
-    return token_generator
+    return _tokenize_source(inspect.getsource(obj))
 
 
-def get_class_column(obj: type) -> int:
-    """Determines the column number for class variables in a class."""
+def _get_class_column(tokens: Iterable[tokenize.TokenInfo]) -> int:
+    """Determines the column number for class variables in a class, given the tokens of the class."""
     first_line = 1
-    for token_type, token, (start_line, start_column), (end_line, end_column), line in tokenize_source(obj):
+    for token_type, token, (start_line, start_column), (end_line, end_column), line in tokens:
         if token.strip() == "@":
             first_line += 1
         if start_line <= first_line or token.strip() == "":
@@ -203,10 +207,18 @@ def get_class_column(obj: type) -> int:
         return start_column
 
 
-def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, int]]]]:
-    """Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code."""
+def get_class_column(cls: type) -> int:
+    """Determines the column number for class variables in a class."""
+    return _get_class_column(tokenize_source(cls))
+
+
+def _source_line_to_tokens(tokens: Iterable[tokenize.TokenInfo]) -> Dict[int, List[Dict[str, Union[str, int]]]]:
+    """
+    Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code,
+    given the tokens of the object's source code.
+    """
     line_to_tokens = {}
-    for token_type, token, (start_line, start_column), (end_line, end_column), line in tokenize_source(obj):
+    for token_type, token, (start_line, start_column), (end_line, end_column), line in tokens:
         line_to_tokens.setdefault(start_line, []).append({
             'token_type': token_type,
             'token': token,
@@ -220,13 +232,19 @@ def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, in
     return line_to_tokens
 
 
-def get_subsequent_assign_lines(cls: type) -> Set[int]:
-    """For all multiline assign statements, get the line numbers after the first line of the assignment."""
-    # Get source code of class
-    source = inspect.getsource(cls)
+def source_line_to_tokens(obj: object) -> Dict[int, List[Dict[str, Union[str, int]]]]:
+    """Gets a dictionary mapping from line number to a dictionary of tokens on that line for an object's source code."""
+    return _source_line_to_tokens(tokenize_source(obj))
+
+
+def _get_subsequent_assign_lines(source_cls: str) -> Set[int]:
+    """
+    For all multiline assign statements, get the line numbers after the first line of the assignment,
+    given the source code of the object.
+    """
 
     # Parse source code using ast (with an if statement to avoid indentation errors)
-    source = f"if True:\n{textwrap.indent(source, ' ')}"
+    source = f"if True:\n{textwrap.indent(source_cls, ' ')}"
     body = ast.parse(source).body[0]
 
     # Set up warning message
@@ -265,18 +283,25 @@ def get_subsequent_assign_lines(cls: type) -> Set[int]:
 
     return assign_lines
 
+def get_subsequent_assign_lines(cls: type) -> Set[int]:
+    """For all multiline assign statements, get the line numbers after the first line of the assignment."""
+    return _get_subsequent_assign_lines(inspect.getsource(cls))
 
 def get_class_variables(cls: type) -> Dict[str, Dict[str, str]]:
     """Returns a dictionary mapping class variables to their additional information (currently just comments)."""
+    # Get the source code and tokens of the class
+    source_cls = inspect.getsource(cls)
+    tokens = tuple(_tokenize_source(source_cls))
+
     # Get mapping from line number to tokens
-    line_to_tokens = source_line_to_tokens(cls)
+    line_to_tokens = _source_line_to_tokens(tokens)
 
     # Get class variable column number
-    class_variable_column = get_class_column(cls)
+    class_variable_column = _get_class_column(tokens)
 
     # For all multiline assign statements, get the line numbers after the first line of the assignment
     # This is used to avoid identifying comments in multiline assign statements
-    subsequent_assign_lines = get_subsequent_assign_lines(cls)
+    subsequent_assign_lines = _get_subsequent_assign_lines(source_cls)
 
     # Extract class variables
     class_variable = None

--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -264,6 +264,11 @@ def get_subsequent_assign_lines(source_cls: str) -> Set[int]:
     assign_lines = set()
     for node in cls_body.body:
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            # Check if the end line number is found
+            if node.end_lineno is None:
+                warnings.warn(parse_warning)
+                return set()
+
             # Get line number of assign statement excluding the first line (and minus 1 for the if statement)
             assign_lines |= set(range(node.lineno, node.end_lineno))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentTypeError
+import inspect
 import json
 import os
 import subprocess
@@ -11,6 +12,7 @@ from tap.utils import (
     get_class_column,
     get_class_variables,
     GitInfo,
+    tokenize_source,
     type_to_str,
     get_literals,
     TupleTypeEnforcer,
@@ -145,7 +147,8 @@ class ClassColumnTests(TestCase):
         class SimpleColumn:
             arg = 2
 
-        self.assertEqual(get_class_column(SimpleColumn), 12)
+        tokens = tokenize_source(inspect.getsource(SimpleColumn))
+        self.assertEqual(get_class_column(tokens), 12)
 
     def test_column_comment(self):
         class CommentColumn:
@@ -158,28 +161,32 @@ class ClassColumnTests(TestCase):
 
             arg = 2
 
-        self.assertEqual(get_class_column(CommentColumn), 12)
+        tokens = tokenize_source(inspect.getsource(CommentColumn))
+        self.assertEqual(get_class_column(tokens), 12)
 
     def test_column_space(self):
         class SpaceColumn:
 
             arg = 2
 
-        self.assertEqual(get_class_column(SpaceColumn), 12)
+        tokens = tokenize_source(inspect.getsource(SpaceColumn))
+        self.assertEqual(get_class_column(tokens), 12)
 
     def test_column_method(self):
         class FuncColumn:
             def func(self):
                 pass
 
-        self.assertEqual(get_class_column(FuncColumn), 12)
+        tokens = tokenize_source(inspect.getsource(FuncColumn))
+        self.assertEqual(get_class_column(tokens), 12)
 
     def test_dataclass(self):
         @class_decorator
         class DataclassColumn:
             arg: int = 5
 
-        self.assertEqual(get_class_column(DataclassColumn), 12)
+        tokens = tokenize_source(inspect.getsource(DataclassColumn))
+        self.assertEqual(get_class_column(tokens), 12)
 
     def test_dataclass_method(self):
         def wrapper(f):
@@ -191,7 +198,8 @@ class ClassColumnTests(TestCase):
             def func(self):
                 pass
 
-        self.assertEqual(get_class_column(DataclassColumn), 12)
+        tokens = tokenize_source(inspect.getsource(DataclassColumn))
+        self.assertEqual(get_class_column(tokens), 12)
 
 
 class ClassVariableTests(TestCase):


### PR DESCRIPTION
The most expensive thing (by far) in all the code is parsing the comments of the class variables, and in particular getting the source code of the classes with `inspect.getsource` and `tokenize.generate_tokens`.

I noticed 2 bottlenecks about this:
  - The biggest: `issubclass(Tap, Tap) is True`!  This caused both functions to be called for `Tap` itself, which is quite large and so they had trouble
  - The two functions where called many times for one class. I suspect there is already some caching involved on the `inspect` side anyway, but it will always be better not to count on that. The idea is to replace the `obj` parameter in each parsing function into what they really need (the tokens or the source code).

## Benchmark

Used ipython for the timeit

With a simple class like this:
```python
from tap import Tap

class Foo(Tap):
    name: str  # Your name
``` 

Before:
```python
In [2]: %timeit Foo()
15.1 ms ± 306 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

After:
```python
In [2]: %timeit Foo()
239 μs ± 4.25 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

Of course, the bigger the class, the slower it will be:
```python
class Foo(Tap):
    name: str  # Your name
    language: str = "Python"  # Programming language
    package: str = "Tap"  # Package name
    stars: int  # Number of stars
    max_stars: int = 5  # Maximum stars
```
```python
In [2]: %timeit Foo()
404 μs ± 4.25 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

It will always be slower than `argparse.ArgumentParser`: 
```python
from argparse import ArgumentParser

def arg_parser():
    parser = ArgumentParser()
    parser.add_argument("--name", type=str, required=True, help="Your name")
    parser.add_argument(
        "--language",
        type=str,
        default="Python",
        help="Programming language",
    )
    parser.add_argument("--package", type=str, default="Tap", help="Package name")
    parser.add_argument("--stars", type=int, required=True, help="Number of stars")
    parser.add_argument("--max_stars", type=int, default=5, help="Maximum stars")
``` 

```python
In [2]: %timeit arg_parser()
113 μs ± 664 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

But it's quite close, i don't think it is an issue now.. as long as the class is small. I don't think that's enough to solve #42.