### PR TITLE
Fix #150

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Typing :: Typed",

--- a/tests/test_to_tap_class.py
+++ b/tests/test_to_tap_class.py
@@ -24,9 +24,14 @@ else:
     _IS_PYDANTIC_V1 = Version(pydantic.__version__) < Version("2.0.0")
 
 
-# To properly test the help message, we need to know how argparse formats it. It changed from 3.8 -> 3.9 -> 3.10
+# To properly test the help message, we need to know how argparse formats it. It changed from 3.8 -> 3.9 -> 3.10 -> 3.13
 _OPTIONS_TITLE = "options" if not sys.version_info < (3, 10) else "optional arguments"
 _ARG_LIST_DOTS = "..." if not sys.version_info < (3, 9) else "[ARG_LIST ...]"
+_ARG_WITH_ALIAS = (
+    "-arg, --argument_with_really_long_name ARGUMENT_WITH_REALLY_LONG_NAME"
+    if not sys.version_info < (3, 13)
+    else "-arg ARGUMENT_WITH_REALLY_LONG_NAME, --argument_with_really_long_name ARGUMENT_WITH_REALLY_LONG_NAME"
+)
 
 
 @dataclasses.dataclass
@@ -416,7 +421,7 @@ def test_subclasser_complex_help_message(class_or_function_: Any):
     {description}
 
     {_OPTIONS_TITLE}:
-    -arg ARGUMENT_WITH_REALLY_LONG_NAME, --argument_with_really_long_name ARGUMENT_WITH_REALLY_LONG_NAME
+    {_ARG_WITH_ALIAS}
                             (Union[float, int], default=3) This argument has a long name and will be aliased with a short
                             one
     --arg_int ARG_INT     (int, required) some integer


### PR DESCRIPTION
Fix #150 

Python 3.13 changed the way arguments with shorter aliases are presented in the help message. `tests/test_to_tap_class.py` tests for exact string match of the help message, so the test needs to be updated.

## How has this been tested?

Ran `pytest` in an environment with Python 3.13 installed and then in an environment with Python 3.11 installed.

Also added Python 3.13 to the testing workflow