### PR TITLE
Change config_files type to Iterable and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ args.from_dict({
 Note: As with `load`, all required arguments must be present in the dictionary if not already set in the Tap object. All values in the provided dictionary will overwrite values currently in the Tap object.
 
 ### Loading from configuration files
-Configuration files can be loaded along with arguments with the optional flag `config_files: List[str]`. Arguments passed in from the command line overwrite arguments from the configuration files. Arguments in configuration files that appear later in the list overwrite the arguments in previous configuration files.
+Configuration files can be loaded along with arguments with the optional flag `config_files: Iterable[str]`. Arguments passed in from the command line overwrite arguments from the configuration files. Arguments in configuration files that appear later in the list overwrite the arguments in previous configuration files.
 
 For example, if you have the config file `my_config.txt`
 ```

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -53,7 +53,7 @@ class Tap(ArgumentParser):
         *args,
         underscores_to_dashes: bool = False,
         explicit_bool: bool = False,
-        config_files: Optional[list[PathLike]] = None,
+        config_files: Optional[Sequence[PathLike]] = None,
         **kwargs,
     ) -> None:
         """Initializes the Tap instance.
@@ -63,7 +63,7 @@ class Tap(ArgumentParser):
         :param explicit_bool: Booleans can be specified on the command line as "--arg True" or "--arg False"
                               rather than "--arg". Additionally, booleans can be specified by prefixes of True and False
                               with any capitalization as well as 1 or 0.
-        :param config_files: A list of paths to configuration files containing the command line arguments
+        :param config_files: A sequence of paths to configuration files containing the command line arguments
                              (e.g., '--arg1 a1 --arg2 a2'). Arguments passed in from the command line
                              overwrite arguments from the configuration files. Arguments in configuration files
                              that appear later in the list overwrite the arguments in previous configuration files.
@@ -689,7 +689,7 @@ class Tap(ArgumentParser):
 
         return self
 
-    def _load_from_config_files(self, config_files: Optional[list[str]]) -> list[str]:
+    def _load_from_config_files(self, config_files: Optional[Sequence[PathLike]]) -> list[str]:
         """Loads arguments from a list of configuration files containing command line arguments.
 
         :param config_files: A list of paths to configuration files containing the command line arguments

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from pprint import pformat
 from shlex import quote, split
 from types import MethodType
-from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Set, Tuple, TypeVar, Union, get_type_hints
 from typing_inspect import is_literal_type
 
 from tap.utils import (
@@ -53,7 +53,7 @@ class Tap(ArgumentParser):
         *args,
         underscores_to_dashes: bool = False,
         explicit_bool: bool = False,
-        config_files: Optional[Sequence[PathLike]] = None,
+        config_files: Optional[Iterable[PathLike]] = None,
         **kwargs,
     ) -> None:
         """Initializes the Tap instance.
@@ -689,7 +689,7 @@ class Tap(ArgumentParser):
 
         return self
 
-    def _load_from_config_files(self, config_files: Optional[Sequence[PathLike]]) -> list[str]:
+    def _load_from_config_files(self, config_files: Optional[Iterable[PathLike]]) -> list[str]:
         """Loads arguments from a list of configuration files containing command line arguments.
 
         :param config_files: A list of paths to configuration files containing the command line arguments

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -690,12 +690,12 @@ class Tap(ArgumentParser):
         return self
 
     def _load_from_config_files(self, config_files: Optional[Iterable[PathLike]]) -> list[str]:
-        """Loads arguments from a list of configuration files containing command line arguments.
+        """Loads arguments from an iterable of configuration files containing command line arguments.
 
-        :param config_files: A list of paths to configuration files containing the command line arguments
+        :param config_files: An iterable of paths to configuration files containing the command line arguments
                              (e.g., '--arg1 a1 --arg2 a2'). Arguments passed in from the command line
                              overwrite arguments from the configuration files. Arguments in configuration files
-                             that appear later in the list overwrite the arguments in previous configuration files.
+                             that appear later in the iterable overwrite the arguments in previous configuration files.
         :return: A list of the contents of each config file in order of increasing precedence (highest last).
         """
         args_from_config = []

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -63,7 +63,7 @@ class Tap(ArgumentParser):
         :param explicit_bool: Booleans can be specified on the command line as "--arg True" or "--arg False"
                               rather than "--arg". Additionally, booleans can be specified by prefixes of True and False
                               with any capitalization as well as 1 or 0.
-        :param config_files: A sequence of paths to configuration files containing the command line arguments
+        :param config_files: An iterable of paths to configuration files containing the command line arguments
                              (e.g., '--arg1 a1 --arg2 a2'). Arguments passed in from the command line
                              overwrite arguments from the configuration files. Arguments in configuration files
                              that appear later in the list overwrite the arguments in previous configuration files.

--- a/tests/test_load_config_files.py
+++ b/tests/test_load_config_files.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 import unittest
 from unittest import TestCase
 
@@ -99,6 +99,24 @@ class LoadConfigFilesTests(TestCase):
                 f2.write("--a 1")
 
             args = MultipleTap(config_files=[fname1, fname2]).parse_args([])
+
+        self.assertEqual(args.a, 1)
+        self.assertEqual(args.b, "two")
+
+    def test_config_as_iterator(self) -> None:
+        class MultipleTap(Tap):
+            a: int
+            b: str = "b"
+
+        with NamedTemporaryFile() as config1, NamedTemporaryFile() as config2:
+
+            with open(config1.name, "w") as f1, open(config2.name, "w") as f2:
+                f1.write("--b two")
+                f2.write("--a 1")
+
+            config_iter = (cf for cf in [config1.name, config2.name])
+
+            args = MultipleTap(config_files=config_iter).parse_args([])
 
         self.assertEqual(args.a, 1)
         self.assertEqual(args.b, "two")

--- a/tests/test_load_config_files.py
+++ b/tests/test_load_config_files.py
@@ -108,13 +108,14 @@ class LoadConfigFilesTests(TestCase):
             a: int
             b: str = "b"
 
-        with NamedTemporaryFile() as config1, NamedTemporaryFile() as config2:
+        with TemporaryDirectory() as temp_dir:
+            fname1, fname2 = os.path.join(temp_dir, "config1.txt"), os.path.join(temp_dir, "config2.txt")
 
-            with open(config1.name, "w") as f1, open(config2.name, "w") as f2:
+            with open(fname1, "w") as f1, open(fname2, "w") as f2:
                 f1.write("--b two")
                 f2.write("--a 1")
 
-            config_iter = (cf for cf in [config1.name, config2.name])
+            config_iter = (cf for cf in [fname1, fname2])
 
             args = MultipleTap(config_files=config_iter).parse_args([])
 


### PR DESCRIPTION
I have a situation where I have a non-list of config files. Looking at the source, any `Sequence` and even `Iterable` should be ok as they are instantly consumed.

This PR changes the type of `config_files: list[PathLike]` to `config_files: Iterable[PathLike]`.

---

Furthermore chaning the type (to at least Sequence) does not raise type errors for users when they pass a pure list to `config_files`:

```python
import os

my_config_paths: list[os.PathLike] = []

config_files_argument: list[str | os.PathLike] = config_paths  # type error as list is invariant, should use a covariant type
```