### PR TITLE
Add TapIgnore

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ Running `python square.py --num 2` will print `The square of your number is 4.0.
 
 Tap requires Python 3.10+
 
-To install Tap from PyPI run: 
+To install Tap from PyPI run:
 
-```
+```shell
 pip install typed-argument-parser
 ```
 
 <details>
 <summary>To install Tap from source, run the following commands:</summary>
 
-```
+```shell
 git clone https://github.com/swansonk14/typed-argument-parser.git
 cd typed-argument-parser
 pip install -e .
@@ -61,7 +61,7 @@ pip install -e .
 <details>
 <summary>To develop this package, install development requirements (in a virtual environment):</summary>
 
-```
+```shell
 python -m pip install -e ".[dev]"
 ```
 
@@ -69,7 +69,7 @@ Use [`flake8`](https://github.com/PyCQA/flake8) linting.
 
 To run tests, run:
 
-```
+```shell
 pytest
 ```
 
@@ -77,35 +77,53 @@ pytest
 
 ## Table of Contents
 
-* [Installation](#installation)
-* [Table of Contents](#table-of-contents)
-* [Tap is Python-native](#tap-is-python-native)
-* [Tap features](#tap-features)
-  + [Arguments](#arguments)
-  + [Tap help](#tap-help)
-  + [Configuring arguments](#configuring-arguments)
-    - [Adding special argument behavior](#adding-special-argument-behavior)
-    - [Adding subparsers](#adding-subparsers)
-  + [Types](#types)
-  + [Argument processing](#argument-processing)
-  + [Processing known args](#processing-known-args)
-  + [Subclassing](#subclassing)
-  + [Printing](#printing)
-  + [Reproducibility](#reproducibility)
-  + [Saving and loading arguments](#saving-and-loading-arguments)
-  + [Loading from configuration files](#loading-from-configuration-files)
-* [tapify](#tapify)
-  + [Examples](#examples)
-    - [Function](#function)
-    - [Class](#class)
-    - [Dataclass](#dataclass)
-  + [tapify help](#tapify-help)
-  + [Command line vs explicit arguments](#command-line-vs-explicit-arguments)
-  + [Known args](#known-args)
-* [Convert to a `Tap` class](#convert-to-a-tap-class)
-  + [`to_tap_class` examples](#to_tap_class-examples)
-    - [Simple](#simple)
-    - [Complex](#complex)
+- [Typed Argument Parser (Tap)](#typed-argument-parser-tap)
+  - [Installation](#installation)
+  - [Table of Contents](#table-of-contents)
+  - [Tap is Python-native](#tap-is-python-native)
+  - [Tap features](#tap-features)
+    - [Arguments](#arguments)
+    - [Tap help](#tap-help)
+    - [Configuring arguments](#configuring-arguments)
+      - [Adding special argument behavior](#adding-special-argument-behavior)
+      - [Adding subparsers](#adding-subparsers)
+    - [Types](#types)
+      - [`str`, `int`, and `float`](#str-int-and-float)
+      - [`bool`](#bool)
+      - [`Optional`](#optional)
+      - [`List`](#list)
+      - [`Set`](#set)
+      - [`Tuple`](#tuple)
+      - [`Literal`](#literal)
+      - [`Union`](#union)
+      - [Complex Types](#complex-types)
+    - [Ignore Attribute](#ignore-attribute)
+    - [Argument processing](#argument-processing)
+    - [Processing known args](#processing-known-args)
+    - [Subclassing](#subclassing)
+    - [Printing](#printing)
+    - [Reproducibility](#reproducibility)
+      - [Reproducibility info](#reproducibility-info)
+    - [Conversion Tap to and from dictionaries](#conversion-tap-to-and-from-dictionaries)
+    - [Saving and loading arguments](#saving-and-loading-arguments)
+      - [Save](#save)
+      - [Load](#load)
+      - [Load from dict](#load-from-dict)
+    - [Loading from configuration files](#loading-from-configuration-files)
+  - [tapify](#tapify)
+    - [Examples](#examples)
+      - [Function](#function)
+      - [Class](#class)
+      - [Dataclass](#dataclass)
+      - [Pydantic](#pydantic)
+    - [tapify help](#tapify-help)
+    - [Command line vs explicit arguments](#command-line-vs-explicit-arguments)
+    - [Known args](#known-args)
+    - [Explicit boolean arguments](#explicit-boolean-arguments)
+  - [Convert to a `Tap` class](#convert-to-a-tap-class)
+    - [`to_tap_class` examples](#to_tap_class-examples)
+      - [Simple](#simple)
+      - [Complex](#complex)
 
 ## Tap is Python-native
 
@@ -361,6 +379,33 @@ args = Args().parse_args('--aged_person Tapper,27'.split())
 print(f'{args.aged_person.name} is {args.aged_person.age}')  # Tapper is 27
 ```
 
+### Ignore Attribute
+
+Sometimes you may want to define attributes that should not be parsed as command line arguments, but you still want to type them.
+This can be achieved by using `TapIgnore`.
+
+```python
+from tap import Tap, TapIgnore
+
+class MyTap(Tap):
+    # Regular arguments (will be parsed)
+    package: str
+    stars: int = 5
+
+    # Ignored attributes (will not be parsed)
+    internal_counter: TapIgnore[int] = 0
+
+args = MyTap().parse_args(["--help"])
+```
+
+```txt
+usage: ipython --package PACKAGE [--stars STARS] [-h]
+
+options:
+  --package PACKAGE  (str, required)
+  --stars STARS      (int, default=5)
+  -h, --help         show this help message and exit
+```
 
 ### Argument processing
 
@@ -863,7 +908,7 @@ Running `python person.py --name Jesse --age 1` prints `My name is Jesse.` follo
 
 ### Explicit boolean arguments
 
-Tapify supports explicit specification of boolean arguments (see [bool](#bool) for more details). By default, `explicit_bool=False` and it can be set with `tapify(..., explicit_bool=True)`. 
+Tapify supports explicit specification of boolean arguments (see [bool](#bool) for more details). By default, `explicit_bool=False` and it can be set with `tapify(..., explicit_bool=True)`.
 
 ## Convert to a `Tap` class
 
@@ -903,7 +948,7 @@ if __name__ == "__main__":
 
 Running `python main.py --package tap` will print `Project instance: package='tap' is_cool=True stars=5`.
 
-### Complex
+#### Complex
 
 The general pattern is:
 

--- a/src/tap/__init__.py
+++ b/src/tap/__init__.py
@@ -5,13 +5,16 @@ Typed Argument Parser
 __version__ = "1.11.0"
 
 from argparse import ArgumentError, ArgumentTypeError
+
 from tap.tap import Tap
 from tap.tapify import tapify, to_tap_class
+from tap.utils import TapIgnore
 
 __all__ = [
     "ArgumentError",
     "ArgumentTypeError",
     "Tap",
+    "TapIgnore",
     "tapify",
     "to_tap_class",
     "__version__",

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -505,7 +505,7 @@ class Tap(ArgumentParser):
         return self
 
     @classmethod
-    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> dict[str, Any] | dict:
+    def _get_from_self_and_super(cls, extract_func: Callable[[type], dict]) -> dict[str, Any]:
         """Returns a dictionary mapping variable names to values.
 
         Variables and values are extracted from classes using key starting

--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -1,17 +1,20 @@
-from argparse import ArgumentParser, ArgumentTypeError
 import ast
-from base64 import b64encode, b64decode
 import inspect
-from io import StringIO
-from json import JSONEncoder
 import os
 import pickle
 import re
 import subprocess
+import sys
 import textwrap
 import tokenize
+import warnings
+from argparse import ArgumentParser, ArgumentTypeError
+from base64 import b64decode, b64encode
+from io import StringIO
+from json import JSONEncoder
 from types import UnionType
 from typing import (
+    Annotated,
     Any,
     Callable,
     Generator,
@@ -19,10 +22,12 @@ from typing import (
     Iterator,
     Literal,
     Optional,
+    TypeAlias,
+    TypeVar,
 )
-from typing_inspect import get_args as typing_inspect_get_args, get_origin as typing_inspect_get_origin
-import warnings
 
+from typing_inspect import get_args as typing_inspect_get_args
+from typing_inspect import get_origin as typing_inspect_get_origin
 
 NO_CHANGES_STATUS = """nothing to commit, working tree clean"""
 PRIMITIVES = (str, int, float, bool)
@@ -594,3 +599,24 @@ def get_args(tp: Any) -> tuple[type, ...]:
         return tp.__args__
 
     return typing_inspect_get_args(tp)
+
+
+_T = TypeVar("_T")
+
+
+class _TapIgnoreMarker:
+    """Internal marker that if present in a type annotation indicates that the argument should be ignored."""
+
+
+# TODO: Python 3.12 turn this into a TypeAliasType for better IDE tooltips
+TapIgnore: TypeAlias = Annotated[_T, _TapIgnoreMarker]
+"""
+Type annotation to indicate that an argument should be ignored by Tap and not be added as an argument.
+
+Usage:
+    from tap import Tap, TapIgnore
+
+    class Args(Tap):
+        a: int
+        e: TapIgnore[int] = 5
+"""

--- a/src/tap/utils.py
+++ b/src/tap/utils.py
@@ -618,5 +618,7 @@ Usage:
 
     class Args(Tap):
         a: int
+
+        # TapIgnore is generic and preserves the type of the ignored attribute
         e: TapIgnore[int] = 5
 """

--- a/tests/test_tap_ignore.py
+++ b/tests/test_tap_ignore.py
@@ -29,6 +29,9 @@ class TapIgnoreTests(unittest.TestCase):
         self.assertIn("c", actions)
         self.assertNotIn("d", actions)
         self.assertNotIn("e", actions)
+        self.assertNotIn("b", args.class_variables)
+        self.assertNotIn("d", args.class_variables)
+        self.assertNotIn("e", args.class_variables)
 
     def test_tap_ignore_no_default(self):
         class Args(Tap):
@@ -74,6 +77,9 @@ class TapIgnoreTests(unittest.TestCase):
         self.assertNotIn("base_ignore", actions)
         self.assertIn("sub_keep", actions)
         self.assertNotIn("sub_ignore", actions)
+        self.assertNotIn("b", args.class_variables)
+        self.assertNotIn("d", args.class_variables)
+        self.assertNotIn("e", args.class_variables)
 
     def test_tap_ignore_subclass_override(self):
         # Case 1: Override ignored with argument

--- a/tests/test_tap_ignore.py
+++ b/tests/test_tap_ignore.py
@@ -1,0 +1,103 @@
+import unittest
+from typing import Annotated
+from tap import Tap, TapIgnore
+
+
+class TapIgnoreTests(unittest.TestCase):
+    def test_tap_ignore(self):
+        class Args(Tap):
+            a: int
+            b: TapIgnore[int] = 2
+            c: Annotated[int, "metadata"] = 3
+            d: Annotated[TapIgnore[int], "metadata"] = 4
+            e: TapIgnore[Annotated[int, "metadata"]] = 5
+
+        args = Args().parse_args(["--a", "1"])
+
+        self.assertEqual(args.a, 1)
+        self.assertEqual(args.b, 2)
+        self.assertEqual(args.c, 3)
+        self.assertEqual(args.d, 4)
+        self.assertEqual(args.e, 5)
+
+        # Check that b is not in the help message (indirectly checking it's not an argument)
+        # Or check _actions
+
+        actions = {a.dest for a in args._actions}
+        self.assertIn("a", actions)
+        self.assertNotIn("b", actions)
+        self.assertIn("c", actions)
+        self.assertNotIn("d", actions)
+        self.assertNotIn("e", actions)
+
+    def test_tap_ignore_no_default(self):
+        class Args(Tap):
+            a: int
+            b: TapIgnore[int]
+
+        # If b is ignored, it shouldn't be required by argparse
+        # But if it has no default, accessing it might raise AttributeError if not set?
+        # Tap doesn't set it if it's not in arguments.
+
+        args = Args().parse_args(["--a", "1"])
+        self.assertEqual(args.a, 1)
+
+        # b should not be set
+        with self.assertRaises(AttributeError):
+            _ = args.b
+
+    def test_tap_ignore_annotated_unwrapping(self):
+        class Args(Tap):
+            a: Annotated[int, "some metadata"]
+
+        args = Args().parse_args(["--a", "1"])
+        self.assertEqual(args.a, 1)
+
+    def test_tap_ignore_subclass(self):
+        class BaseArgs(Tap):
+            base_keep: int
+            base_ignore: TapIgnore[str] = "ignore_me"
+
+        class SubArgs(BaseArgs):
+            sub_keep: float
+            sub_ignore: TapIgnore[bool] = True
+
+        args = SubArgs().parse_args(["--base_keep", "1", "--sub_keep", "2.5"])
+
+        self.assertEqual(args.base_keep, 1)
+        self.assertEqual(args.base_ignore, "ignore_me")
+        self.assertEqual(args.sub_keep, 2.5)
+        self.assertEqual(args.sub_ignore, True)
+
+        actions = {a.dest for a in args._actions}
+        self.assertIn("base_keep", actions)
+        self.assertNotIn("base_ignore", actions)
+        self.assertIn("sub_keep", actions)
+        self.assertNotIn("sub_ignore", actions)
+
+    def test_tap_ignore_subclass_override(self):
+        # Case 1: Override ignored with argument
+        class Base1(Tap):
+            a: TapIgnore[int] = 1
+
+        class Sub1(Base1):
+            a: int = 2
+
+        args1 = Sub1().parse_args([])
+        self.assertEqual(args1.a, 2)
+        self.assertIn("a", {a.dest for a in args1._actions})
+
+        # Case 2: Override argument with ignored
+        class Base2(Tap):
+            b: int = 3
+
+        class Sub2(Base2):
+            b: TapIgnore[int] = 4
+
+        args2 = Sub2().parse_args([])
+        self.assertEqual(args2.b, 4)
+        self.assertNotIn("b", {a.dest for a in args2._actions})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a generic `TapIgnore` - which is a `Annotated[T, _TapIgnoreMarker]` which ignores arguments.

As it is just a generic Annotated should work without issues for type-checkers.

Resolves: #75
Closes: #170, #92


Question:  
For IDEs it would be better to use TypeAliasType for TapIgnore.`tap` itself avoids using `typing_extensions` but it is in the dependency chain from `typing-inspect` - so it would be usable. Not sure how your stance is to use it or not.
