### PR TITLE
Remove extras from to_tap_class annotations & add them for pydantic models

### DIFF
--- a/src/tap/tapify.py
+++ b/src/tap/tapify.py
@@ -271,7 +271,7 @@ def _tap_data(class_or_function: _ClassOrFunction, param_to_description: dict[st
     return _tap_data_from_class_or_function(class_or_function, func_kwargs, param_to_description)
 
 def _remove_extras_from_annotation(annotation):
-    """Removes extras from annotation types, e.g., Annotated, Optional, etc."""
+    """Removes extras from annotation types, e.g., Annotated, etc."""
     return get_type_hints(SimpleNamespace(__annotations__ = {"dummy": annotation}))["dummy"]
 
 def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:

--- a/tests/test_to_tap_class.py
+++ b/tests/test_to_tap_class.py
@@ -7,7 +7,7 @@ import dataclasses
 import io
 import re
 import sys
-from typing import Any, Callable, List, Literal, Optional, Type, Union
+from typing import Annotated, Any, Callable, List, Literal, Optional, Type, Union
 
 import pytest
 
@@ -688,3 +688,12 @@ class TestMethodResolutionOrder:
         args = ["--d", "4"]
         with pytest.raises(SystemExit):
             TapGrandchild().parse_args(args)
+
+def test_extras_removal():
+    class Parent:
+        def __init__(self, an_int: Annotated[int, "metadata"] = 1):
+            pass
+
+    tapped = to_tap_class(Parent)
+    assert tapped()._annotations["an_int"] == int
+    assert tapped()._annotations_with_extras["an_int"] == Annotated[int, "metadata"]


### PR DESCRIPTION
Separate cleaned annotations and annotations with extras to be equivalent to the Tap class interface.

Resolves: #173

- #173

Lets see if anything goes wrong with the tests