### PR TITLE
Allow kwargs throughput when using tapify and TapIgnore

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,15 @@ Now we are going to highlight some of our favorite features and give examples of
 ### Arguments
 
 Arguments are specified as class variables defined in a subclass of `Tap`. Variables defined as `name: type` are required arguments while variables defined as `name: type = value` are not required and default to the provided value.
+Additionally, positional arguments can be specified using the `Positional` for annotation.
 
 ```python
+from tap import Tap, Positional
+
 class MyTap(Tap):
     required_arg: str
     default_arg: str = 'default value'
+    positional_arg: Positional[int]
 ```
 
 ### Tap help
@@ -232,6 +236,7 @@ Since Tap is a wrapper around argparse, Tap provides all of the same functionali
 We detail these two functions below.
 
 #### Adding special argument behavior
+
 In the `configure` method, call `self.add_argument` just as you would use argparse's `add_argument`. For example,
 
 ```python

--- a/src/tap/__init__.py
+++ b/src/tap/__init__.py
@@ -8,11 +8,12 @@ from argparse import ArgumentError, ArgumentTypeError
 
 from tap.tap import Tap
 from tap.tapify import tapify, to_tap_class
-from tap.utils import TapIgnore
+from tap.utils import TapIgnore, Positional
 
 __all__ = [
     "ArgumentError",
     "ArgumentTypeError",
+    "Positional",
     "Tap",
     "TapIgnore",
     "tapify",

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -325,13 +325,16 @@ class Tap(ArgumentParser):
                 f"Argument '{variable}' is marked as TapIgnore and cannot be added as a command line argument. "
                 "Either remove the TapIgnore annotation or remove the add_argument call."
             )
-        if self._is_argument_annotated_positional(variable) and not is_positional_arg(*name_or_flags):
+        is_positional = self._is_argument_annotated_positional(variable)
+        if is_positional and not is_positional_arg(*name_or_flags):
             raise ValueError(
                 f"Argument '{variable}' is marked as Positional "
                 f"and cannot be added with option flags {name_or_flags}. "
                 "Either remove the Positional annotation "
                 "or change the add_argument call to use a positional argument."
             )
+        if is_positional and "required" in kwargs:
+            raise TypeError("'required' is an invalid argument for positionals")
 
         self.argument_buffer[variable] = (name_or_flags, kwargs)
 

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -327,9 +327,9 @@ class Tap(ArgumentParser):
             )
         if self._is_argument_annotated_positional(variable) and not is_positional_arg(*name_or_flags):
             raise ValueError(
-                f"Argument '{variable}' is marked as TapPositional "
+                f"Argument '{variable}' is marked as Positional "
                 f"and cannot be added with option flags {name_or_flags}. "
-                "Either remove the TapPositional annotation "
+                "Either remove the Positional annotation "
                 "or change the add_argument call to use a positional argument."
             )
 

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -325,15 +325,16 @@ class Tap(ArgumentParser):
                 f"Argument '{variable}' is marked as TapIgnore and cannot be added as a command line argument. "
                 "Either remove the TapIgnore annotation or remove the add_argument call."
             )
-        is_positional = self._is_argument_annotated_positional(variable)
-        if is_positional and not is_positional_arg(*name_or_flags):
+        is_annotated_positional = self._is_argument_annotated_positional(variable)
+        is_positional_arg_name = is_positional_arg(*name_or_flags)
+        if is_annotated_positional and not is_positional_arg_name:
             raise ValueError(
                 f"Argument '{variable}' is marked as Positional "
                 f"and cannot be added with option flags {name_or_flags}. "
                 "Either remove the Positional annotation "
                 "or change the add_argument call to use a positional argument."
             )
-        if is_positional and "required" in kwargs:
+        if (is_annotated_positional or is_positional_arg_name) and "required" in kwargs:
             raise TypeError("'required' is an invalid argument for positionals")
 
         self.argument_buffer[variable] = (name_or_flags, kwargs)

--- a/src/tap/tapify.py
+++ b/src/tap/tapify.py
@@ -282,7 +282,9 @@ def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:
             for arg_data in args_data:
                 variable = arg_data.name
                 if variable not in self.class_variables:
-                    self._annotations[variable] = str if arg_data.annotation is Any else arg_data.annotation
+                    annotation = str if arg_data.annotation is Any else arg_data.annotation
+                    self._annotations_with_extras[variable] = annotation
+                    self._annotations[variable] = annotation
                     self.class_variables[variable] = {"comment": arg_data.description or ""}
                     if arg_data.is_required:
                         kwargs = {}

--- a/src/tap/tapify.py
+++ b/src/tap/tapify.py
@@ -312,6 +312,7 @@ def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:
                     else:
                         kwargs = dict(required=False, default = arg_data.default)
                     if self._is_argument_annotated_positional(variable):
+                        kwargs.pop("required", None)  # required is for optional args only
                         self.add_argument(variable, **kwargs)
                     else:
                         self.add_argument(f"--{variable}", **kwargs)

--- a/src/tap/tapify.py
+++ b/src/tap/tapify.py
@@ -288,7 +288,10 @@ def _tap_class(args_data: Sequence[_ArgData]) -> type[Tap]:
                         kwargs = {}
                     else:
                         kwargs = dict(required=False, default = arg_data.default)
-                    self.add_argument(f"--{variable}", **kwargs)
+                    if self._is_argument_annotated_positional(variable):
+                        self.add_argument(variable, **kwargs)
+                    else:
+                        self.add_argument(f"--{variable}", **kwargs)
 
             super()._configure()
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -204,6 +204,18 @@ class TestArgparseActions(TestCase):
         args = ExtendListIntTap().parse_args("--arg 1 2 --arg 3 --arg 4 5".split())
         self.assertEqual(args.arg, [0, 1, 2, 3, 4, 5])
 
+    def test_positional_invalid_usage(self):
+        class PositionalTap(Tap):
+            a: Positional[int]
+
+            def configure(self) -> None:
+                self.add_argument("--a")
+
+        with self.assertRaisesRegex(
+            ValueError, "Argument 'a' is marked as Positional and cannot be added with option flags .'--a"
+        ):
+            PositionalTap()
+
     def test_positional_required(self):
         class PositionalRequired(Tap):
             arg: str

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1638,6 +1638,16 @@ class TestPositionalArguments(TestCase):
 
         self.assertEqual(args.a, 1)
 
+    def test_invalid_positional_with_required(self):
+        class PositionalTap(Tap):
+            a: int
+
+            def configure(self) -> None:
+                self.add_argument("a", required=False)
+
+        with self.assertRaises(TypeError):
+            PositionalTap()
+
 
 class TestPickle(TestCase):
     def test_pickle(self):

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1337,30 +1337,44 @@ class TapifyTests(TestCase):
             return f"Hello, {name}!"
         output = tapify(greet, command_line_args=["Alice"])
         self.assertEqual(output, "Hello, Alice!")
+        with self.assertRaises(SystemExist):
+            tapify(greet, command_line_args=[])
+        with self.assertRaises(SystemExist):
+            tapify(greet, command_line_args=["--name Alice"])
+
+        def optional_greet(name: Positional[str] = "Anonymous"):
+            return f"Hello, {name}!"
+        output = tapify(greet, command_line_args=["Alice"])
+        self.assertEqual(output, "Hello, Alice!")
+        with self.assertRaises(SystemExist):
+            tapify(greet, command_line_args=["--name Alice"])
+        output = tapify(greet, command_line_args=[])
+        self.assertEqual(output, "Hello, Anonymous!")
+        
 
     @unittest.skipIf(_IS_PYDANTIC_V1 is None, reason="Pydantic not installed")
     def test_tapify_pydantic_with_positional_annotation(self):
         class PydanticModel(pydantic.BaseModel):
             foo: Positional[int]
 
-        model = tapify(struct_cls, command_line_args=["42"])
+        model = tapify(PydanticModel, command_line_args=["42"])
         self.assertEqual(model.foo, 42)
         with self.assertRaises(SystemExit):
-            tapify(struct_cls, command_line_args=[])
+            tapify(PydanticModel, command_line_args=[])
         with self.assertRaises(SystemExit):
-            tapify(struct_cls, command_line_args=["--foo", "42"])
+            tapify(PydanticModel, command_line_args=["--foo", "42"])
 
     def test_tapify_dataclass_with_positional_annotation(self):
         @dataclass
-        class MyModel:
+        class DataclassModel:
             foo: Positional[int]
 
-        model = tapify(struct_cls, command_line_args=["42"])
+        model = tapify(DataclassModel, command_line_args=["42"])
         self.assertEqual(model.foo, 42)
         with self.assertRaises(SystemExit):
-            tapify(struct_cls, command_line_args=[])
+            tapify(DataclassModel, command_line_args=[])
         with self.assertRaises(SystemExit):
-            tapify(struct_cls, command_line_args=["--foo", "42"])
+            tapify(DataclassModel, command_line_args=["--foo", "42"])
 
 class TestTapifyExplicitBool(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1339,11 +1339,21 @@ class TapifyTests(TestCase):
         self.assertEqual(output, "Hello, Alice!")
 
     def test_tapify_pydantic_with_positional_annotation(self):
-        class MyModel(pydantic.BaseModel):
+        class PydanticModel(pydantic.BaseModel):
             foo: Positional[int]
 
-        model = tapify(MyModel, command_line_args=["42"])
-        self.assertEqual(model.foo, 42)
+        @dataclass
+        class DataclassModel:
+            foo: Positional[int]
+
+        for struct_cls in [PydanticModel, DataclassModel]:
+            with self.subTest(struct_cls=struct_cls.__name__):
+                model = tapify(struct_cls, command_line_args=["42"])
+                self.assertEqual(model.foo, 42)
+                with self.assertRaises(SystemExit):
+                    tapify(struct_cls, command_line_args=[])
+                with self.assertRaises(SystemExit):
+                    tapify(struct_cls, command_line_args=["--foo", "42"])
 
     def test_tapify_dataclass_with_positional_annotation(self):
         @dataclass

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Tuple, Any
 import unittest
 from unittest import TestCase
 
-from tap import tapify
+from tap import tapify, Positional
 
 
 try:
@@ -1332,6 +1332,11 @@ class TapifyTests(TestCase):
             self.assertIn("--b B       (int, required) The second number.", stdout)
             self.assertIn("--c C       (int, required) The third number.", stdout)
 
+    def test_tapify_with_positional_annotation(self):
+        def greet(name: Positional[str]):
+            return f"Hello, {name}!"
+        output = tapify(greet, command_line_args=["Alice"])
+        self.assertEqual(output, "Hello, Alice!")
 
 class TestTapifyExplicitBool(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1337,20 +1337,19 @@ class TapifyTests(TestCase):
             return f"Hello, {name}!"
         output = tapify(greet, command_line_args=["Alice"])
         self.assertEqual(output, "Hello, Alice!")
-        with self.assertRaises(SystemExist):
+        with self.assertRaises(SystemExit):
             tapify(greet, command_line_args=[])
-        with self.assertRaises(SystemExist):
-            tapify(greet, command_line_args=["--name Alice"])
+        with self.assertRaises(SystemExit):
+            tapify(greet, command_line_args=["--name", "Alice"])
 
         def optional_greet(name: Positional[str] = "Anonymous"):
             return f"Hello, {name}!"
-        output = tapify(greet, command_line_args=["Alice"])
-        self.assertEqual(output, "Hello, Alice!")
-        with self.assertRaises(SystemExist):
-            tapify(greet, command_line_args=["--name Alice"])
-        output = tapify(greet, command_line_args=[])
+        output = tapify(optional_greet, command_line_args=["Bob"])
+        self.assertEqual(output, "Hello, Bob!")
+        with self.assertRaises(SystemExit):
+            tapify(optional_greet, command_line_args=["--name", "Bob"])
+        output = tapify(optional_greet, command_line_args=[])
         self.assertEqual(output, "Hello, Anonymous!")
-        
 
     @unittest.skipIf(_IS_PYDANTIC_V1 is None, reason="Pydantic not installed")
     def test_tapify_pydantic_with_positional_annotation(self):

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1338,6 +1338,21 @@ class TapifyTests(TestCase):
         output = tapify(greet, command_line_args=["Alice"])
         self.assertEqual(output, "Hello, Alice!")
 
+    def test_tapify_pydantic_with_positional_annotation(self):
+        class MyModel(pydantic.BaseModel):
+            foo: Positional[int]
+
+        model = tapify(MyModel, command_line_args=["42"])
+        self.assertEqual(model.foo, 42)
+
+    def test_tapify_dataclass_with_positional_annotation(self):
+        @dataclass
+        class MyModel:
+            foo: Positional[int]
+
+        model = tapify(MyModel, command_line_args=["42"])
+        self.assertEqual(model.foo, 42)
+
 class TestTapifyExplicitBool(unittest.TestCase):
     def setUp(self) -> None:
         def cool(is_cool: bool = False) -> "Cool":

--- a/tests/test_tapify.py
+++ b/tests/test_tapify.py
@@ -1338,30 +1338,29 @@ class TapifyTests(TestCase):
         output = tapify(greet, command_line_args=["Alice"])
         self.assertEqual(output, "Hello, Alice!")
 
+    @unittest.skipIf(_IS_PYDANTIC_V1 is None, reason="Pydantic not installed")
     def test_tapify_pydantic_with_positional_annotation(self):
         class PydanticModel(pydantic.BaseModel):
             foo: Positional[int]
 
-        @dataclass
-        class DataclassModel:
-            foo: Positional[int]
-
-        for struct_cls in [PydanticModel, DataclassModel]:
-            with self.subTest(struct_cls=struct_cls.__name__):
-                model = tapify(struct_cls, command_line_args=["42"])
-                self.assertEqual(model.foo, 42)
-                with self.assertRaises(SystemExit):
-                    tapify(struct_cls, command_line_args=[])
-                with self.assertRaises(SystemExit):
-                    tapify(struct_cls, command_line_args=["--foo", "42"])
+        model = tapify(struct_cls, command_line_args=["42"])
+        self.assertEqual(model.foo, 42)
+        with self.assertRaises(SystemExit):
+            tapify(struct_cls, command_line_args=[])
+        with self.assertRaises(SystemExit):
+            tapify(struct_cls, command_line_args=["--foo", "42"])
 
     def test_tapify_dataclass_with_positional_annotation(self):
         @dataclass
         class MyModel:
             foo: Positional[int]
 
-        model = tapify(MyModel, command_line_args=["42"])
+        model = tapify(struct_cls, command_line_args=["42"])
         self.assertEqual(model.foo, 42)
+        with self.assertRaises(SystemExit):
+            tapify(struct_cls, command_line_args=[])
+        with self.assertRaises(SystemExit):
+            tapify(struct_cls, command_line_args=["--foo", "42"])
 
 class TestTapifyExplicitBool(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Fixes: #177 + dataclasses + pydantic cases

Requires: #176

I've build this on the more convenient helper functions of #176. So that would be needed first (or doing some extractions which are more work)^^