### PR TITLE
Remove dependency on typing-inspect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ license = "MIT"
 license-files = [ "LICENSE.txt" ]
 dependencies = [
     "docstring-parser >= 0.15",
-    "typing-inspect >= 0.7.1",
 ]
 requires-python = ">=3.10"
 classifiers = [

--- a/src/tap/tap.py
+++ b/src/tap/tap.py
@@ -22,13 +22,12 @@ from typing import (
     Union,
     get_type_hints,
     get_origin as typing_get_origin,
-    get_args as typing_get_args,
+    get_args,
 )
-from typing_inspect import is_literal_type
 
 from tap.utils import (
     get_class_variables,
-    get_args,
+    is_literal_type,
     get_argument_name,
     get_dest,
     get_origin,
@@ -201,6 +200,7 @@ class Tap(ArgumentParser):
                         var_args = (str, type(None))
 
                     # Raise error if type function is not explicitly provided for Union types (not including Optionals)
+
                     if get_origin(var_type) in UNION_TYPES and not (len(var_args) == 2 and var_args[1] == type(None)):
                         raise ArgumentTypeError(
                             "For Union types, you must include an explicit type function in the configure method. "
@@ -329,7 +329,7 @@ class Tap(ArgumentParser):
         annotations = self._annotations_with_extras if annotations is None else annotations
         if variable in annotations:
             var_type = annotations[variable]
-            if typing_get_origin(var_type) is Annotated and _TapIgnoreMarker in typing_get_args(var_type):
+            if typing_get_origin(var_type) is Annotated and _TapIgnoreMarker in get_args(var_type):
                 return True
         return False
 


### PR DESCRIPTION
Hello,

This project is using a tiny part of `typing-inspect`. Most of what seems to be needed has already been implemented in Python 3.10. Not that `typing-inspect` and its two transitive dependencies (`mypy-extensions`, `typing-extensions`) are bad, but less dependencies always gives more peace of mind, imho. 

Kind regards,
Georgi